### PR TITLE
add a default api host and clean up some debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-cli-plugin-runtime",
   "description": "Adobe I/O Runtime commands for the Adobe I/O CLI",
-  "version": "1.0.0",
+  "version": "1.0.1-dev",
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-runtime/issues",
   "dependencies": {

--- a/src/RuntimeBaseCommand.js
+++ b/src/RuntimeBaseCommand.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const { Command, flags } = require('@oclif/command')
 
-const { propertiesFile, PropertyEnv } = require('./properties')
+const { propertiesFile, PropertyEnv, PropertyDefault } = require('./properties')
 const createDebug = require('debug')
 const debug = createDebug('aio-cli-plugin-runtime')
 const OpenWhisk = require('openwhisk')
@@ -25,8 +25,8 @@ class RuntimeBaseCommand extends Command {
     const options = {
       cert: flags.cert || properties.get('CERT'),
       key: flags.key || properties.get('KEY'),
-      apiversion: flags.apiversion || properties.get('APIVERSION'),
-      apihost: flags.apihost || properties.get('APIHOST'),
+      apiversion: flags.apiversion || properties.get('APIVERSION') || PropertyDefault.APIVERSION,
+      apihost: flags.apihost || properties.get('APIHOST') || PropertyDefault.APIHOST,
       namespace: properties.get('NAMESPACE'),
       api_key: flags.auth || properties.get('AUTH'),
       ignore_certs: flags.insecure

--- a/src/RuntimeBaseCommand.js
+++ b/src/RuntimeBaseCommand.js
@@ -12,8 +12,9 @@ governing permissions and limitations under the License.
 
 const { Command, flags } = require('@oclif/command')
 
-const debug = require('debug')
 const { propertiesFile, PropertyEnv } = require('./properties')
+const createDebug = require('debug')
+const debug = createDebug('aio-cli-plugin-runtime')
 const OpenWhisk = require('openwhisk')
 
 class RuntimeBaseCommand extends Command {
@@ -40,6 +41,8 @@ class RuntimeBaseCommand extends Command {
         }
       })
 
+    debug(options)
+
     return OpenWhisk(options)
   }
 
@@ -49,9 +52,9 @@ class RuntimeBaseCommand extends Command {
     // See https://www.npmjs.com/package/debug for usage in commands
     if (flags.verbose) {
       // verbose just sets the debug filter to everything (*)
-      debug.enable('*')
+      createDebug.enable('*')
     } else if (flags.debug) {
-      debug.enable(flags.debug)
+      createDebug.enable(flags.debug)
     }
   }
 
@@ -63,7 +66,7 @@ class RuntimeBaseCommand extends Command {
       msg = `${msg}: ${err.message}`
 
       if (flags.verbose) {
-        debug.log(err) // for stacktrace when verbose
+        debug(err)
       }
     }
     return this.error(msg)

--- a/src/commands/runtime/property/get.js
+++ b/src/commands/runtime/property/get.js
@@ -14,7 +14,7 @@ const { flags } = require('@oclif/command')
 const { cli } = require('cli-ux')
 const fetch = require('node-fetch')
 const { PropertyKey, PropertyDefault, propertiesFile } = require('../../../properties')
-const debug = require('debug')('property')
+const debug = require('debug')('aio-cli-plugin-runtime/property')
 
 class PropertyGet extends RuntimeBaseCommand {
   async run () {

--- a/src/properties.js
+++ b/src/properties.js
@@ -33,7 +33,7 @@ const PropertyEnv = {
 
 const PropertyDefault = {
   AUTH: '',
-  APIHOST: '',
+  APIHOST: 'https://adobeioruntime.net',
   APIVERSION: 'v1',
   NAMESPACE: '_',
   CERT: '',

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 const fs = require('fs')
 let yaml = require('js-yaml')
-const debug = require('debug')('deploy')
+const debug = require('debug')('aio-cli-plugin-runtime/deploy')
 /**
  * @description returns key value array from the parameters supplied. Used to create --param and --annotation key value pairs
  * @param flag : flags.param or flags.annotation

--- a/test/__fixtures__/property/all-empty-wskprops.txt
+++ b/test/__fixtures__/property/all-empty-wskprops.txt
@@ -1,10 +1,10 @@
-Property                Value               
-whisk auth                                  
-whisk API host                              
-whisk API version       v1                  
-client cert                                 
-client key                                  
-whisk namespace         _                   
-whisk CLI version       1.0                 
-whisk API build version 2019-02-26          
-whisk API build number  A                   
+Property                Value                      
+whisk auth                                         
+whisk API host          https://adobeioruntime.net 
+whisk API version       v1                         
+client cert                                        
+client key                                         
+whisk namespace         _                          
+whisk CLI version       1.0                        
+whisk API build version 2019-02-26                 
+whisk API build number  A                          

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -23,6 +23,13 @@ jest.mock('fs', () => require('jest-plugin-fs/mock'))
 // ensure a mocked openwhisk module for unit-tests
 jest.mock('openwhisk')
 
+// clear env variables
+delete process.env['WHISK_AUTH']
+delete process.env['WHISK_APIHOST']
+delete process.env['WHISK_APIVERSION']
+delete process.env['WHISK_NAMESPACE']
+delete process.env['WSK_CONFIG_FILE']
+
 // trap console log
 beforeEach(() => { stdout.start() })
 afterEach(() => { stdout.stop() })


### PR DESCRIPTION
## Description

* use default api_host of https://adobeioruntime.net if api_host is not specified
* clean up debugging namespaces by adding plugin scope

## Related Issue

tangentially related to https://github.com/adobe/aio-cli-plugin-runtime/issues/14 but it not a full fix, just a first step

## Motivation and Context

if api host is stable then we can allow it to be an optional.  this wont affect people with open wsk files.

## How Has This Been Tested?

* added test coverage

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
