### PR TITLE
output correct help for runtime:activation when --help flag not present

### DIFF
--- a/src/commands/runtime/activation/index.js
+++ b/src/commands/runtime/activation/index.js
@@ -16,7 +16,7 @@ const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
 class IndexCommand extends RuntimeBaseCommand {
   async run () {
     const help = new HHelp(this.config)
-    help.showHelp(['runtime:action', '--help'])
+    help.showHelp(['runtime:activation', '--help'])
   }
 }
 

--- a/src/commands/runtime/deploy/index.js
+++ b/src/commands/runtime/deploy/index.js
@@ -18,30 +18,26 @@ const { flags } = require('@oclif/command')
 class IndexCommand extends RuntimeBaseCommand {
   async run () {
     const { flags } = this.parse(IndexCommand)
-    if (Object.keys(flags).length > 0) {
-      try {
-        // in case of 'aio runtime:deploy' (without the path to the manifest file) the program looks for the manifest file in the current directory.
-        let components = setPaths(flags)
-        let packages = components.packages
-        let deploymentTriggers = components.deploymentTriggers
-        let deploymentPackages = components.deploymentPackages
-        let params = {}
-        if (flags.param) {
-          params = createKeyValueObjectFromFlag(flags.param)
-        } else if (flags['param-file']) {
-          params = createKeyValueObjectFromFile(flags['param-file'])
-        }
 
-        let entities = processPackage(packages, deploymentPackages, deploymentTriggers, params)
-        const ow = await this.wsk()
-        let logger = this.log
-        await deployPackage(entities, ow, logger)
-      } catch (err) {
-        this.handleError('Failed to deploy', err)
+    try {
+      // in case of 'aio runtime:deploy' (without the path to the manifest file) the program looks for the manifest file in the current directory.
+      let components = setPaths(flags)
+      let packages = components.packages
+      let deploymentTriggers = components.deploymentTriggers
+      let deploymentPackages = components.deploymentPackages
+      let params = {}
+      if (flags.param) {
+        params = createKeyValueObjectFromFlag(flags.param)
+      } else if (flags['param-file']) {
+        params = createKeyValueObjectFromFile(flags['param-file'])
       }
-    } else {
-      const help = new HHelp(this.config)
-      return help.showHelp(['runtime:action', '--help'])
+
+      let entities = processPackage(packages, deploymentPackages, deploymentTriggers, params)
+      const ow = await this.wsk()
+      let logger = this.log
+      await deployPackage(entities, ow, logger)
+    } catch (err) {
+      this.handleError('Failed to deploy', err)
     }
   }
 }

--- a/src/commands/runtime/deploy/index.js
+++ b/src/commands/runtime/deploy/index.js
@@ -10,7 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const HHelp = require('@oclif/plugin-help').default
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
 const { createKeyValueObjectFromFlag, createKeyValueObjectFromFile, deployPackage, setPaths, processPackage } = require('../../../runtime-helpers')
 const { flags } = require('@oclif/command')

--- a/src/commands/runtime/deploy/index.js
+++ b/src/commands/runtime/deploy/index.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const HHelp = require('@oclif/plugin-help').default
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
 const { createKeyValueObjectFromFlag, createKeyValueObjectFromFile, deployPackage, setPaths, processPackage } = require('../../../runtime-helpers')
 const { flags } = require('@oclif/command')
@@ -17,25 +18,30 @@ const { flags } = require('@oclif/command')
 class IndexCommand extends RuntimeBaseCommand {
   async run () {
     const { flags } = this.parse(IndexCommand)
-    try {
-      // in case of 'aio runtime:deploy' (without the path to the manifest file) the program looks for the manifest file in the current directory.
-      let components = setPaths(flags)
-      let packages = components.packages
-      let deploymentTriggers = components.deploymentTriggers
-      let deploymentPackages = components.deploymentPackages
-      let params = {}
-      if (flags.param) {
-        params = createKeyValueObjectFromFlag(flags.param)
-      } else if (flags['param-file']) {
-        params = createKeyValueObjectFromFile(flags['param-file'])
-      }
+    if (Object.keys(flags).length > 0) {
+      try {
+        // in case of 'aio runtime:deploy' (without the path to the manifest file) the program looks for the manifest file in the current directory.
+        let components = setPaths(flags)
+        let packages = components.packages
+        let deploymentTriggers = components.deploymentTriggers
+        let deploymentPackages = components.deploymentPackages
+        let params = {}
+        if (flags.param) {
+          params = createKeyValueObjectFromFlag(flags.param)
+        } else if (flags['param-file']) {
+          params = createKeyValueObjectFromFile(flags['param-file'])
+        }
 
-      let entities = processPackage(packages, deploymentPackages, deploymentTriggers, params)
-      const ow = await this.wsk()
-      let logger = this.log
-      await deployPackage(entities, ow, logger)
-    } catch (err) {
-      this.handleError('Failed to deploy', err)
+        let entities = processPackage(packages, deploymentPackages, deploymentTriggers, params)
+        const ow = await this.wsk()
+        let logger = this.log
+        await deployPackage(entities, ow, logger)
+      } catch (err) {
+        this.handleError('Failed to deploy', err)
+      }
+    } else {
+      const help = new HHelp(this.config)
+      return help.showHelp(['runtime:action', '--help'])
     }
   }
 }

--- a/test/commands/runtime/activation/index.test.js
+++ b/test/commands/runtime/activation/index.test.js
@@ -47,7 +47,7 @@ describe('instance methods', () => {
       let spy = jest.spyOn(HHelp.prototype, 'showHelp').mockReturnValue(true)
       command.id = 'pgb'
       return command.run().then(() => {
-        expect(spy).toHaveBeenCalledWith(['runtime:action', '--help'])
+        expect(spy).toHaveBeenCalledWith(['runtime:activation', '--help'])
       })
     })
   })


### PR DESCRIPTION
Also addressed an issue where 'runtime:deploy' when called without flags would error, instead of outputting help like the rest of the sub-commands