### PR TITLE
ACNA-382

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm install -g @adobe/aio-cli-plugin-runtime
 $ ./bin/run COMMAND
 running command...
 $ ./bin/run (-v|--version|version)
-@adobe/aio-cli-plugin-runtime/1.0.0 darwin-x64 node-v8.9.4
+@adobe/aio-cli-plugin-runtime/1.0.1 darwin-x64 node-v10.16.1
 $ ./bin/run --help [COMMAND]
 USAGE
   $ ./bin/run COMMAND
@@ -119,9 +119,12 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run rt
 ```
 
-_See code: [src/commands/runtime/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/index.js)_
+_See code: [src/commands/runtime/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/index.js)_
 
 ## `./bin/run runtime:action`
 
@@ -142,9 +145,12 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run rt:action
 ```
 
-_See code: [src/commands/runtime/action/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/action/index.js)_
+_See code: [src/commands/runtime/action/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/action/index.js)_
 
 ## `./bin/run runtime:action:create ACTIONNAME [ACTIONPATH]`
 
@@ -195,9 +201,12 @@ OPTIONS
   --version                              Show version
 
   --web=true|yes|false|no|raw            treat ACTION as a web action or as a raw HTTP web action
+
+ALIASES
+  $ ./bin/run rt:action:create
 ```
 
-_See code: [src/commands/runtime/action/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/action/create.js)_
+_See code: [src/commands/runtime/action/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/action/create.js)_
 
 ## `./bin/run runtime:action:delete ACTIONNAME`
 
@@ -209,9 +218,14 @@ USAGE
 
 OPTIONS
   --json  output raw json
+
+ALIASES
+  $ ./bin/run runtime:action:del
+  $ ./bin/run rt:action:delete
+  $ ./bin/run rt:action:del
 ```
 
-_See code: [src/commands/runtime/action/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/action/delete.js)_
+_See code: [src/commands/runtime/action/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/action/delete.js)_
 
 ## `./bin/run runtime:action:get ACTIONNAME`
 
@@ -235,9 +249,12 @@ OPTIONS
   --save                   save action code to file corresponding with action name
   --save-as=save-as        file to save action code to
   --version                Show version
+
+ALIASES
+  $ ./bin/run rt:action:get
 ```
 
-_See code: [src/commands/runtime/action/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/action/get.js)_
+_See code: [src/commands/runtime/action/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/action/get.js)_
 
 ## `./bin/run runtime:action:invoke ACTIONNAME`
 
@@ -262,9 +279,12 @@ OPTIONS
   --help                       Show help
   --key=key                    client key
   --version                    Show version
+
+ALIASES
+  $ ./bin/run rt:action:invoke
 ```
 
-_See code: [src/commands/runtime/action/invoke.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/action/invoke.js)_
+_See code: [src/commands/runtime/action/invoke.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/action/invoke.js)_
 
 ## `./bin/run runtime:action:list`
 
@@ -288,9 +308,18 @@ OPTIONS
   --json                   output raw json
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run runtime:action:ls
+  $ ./bin/run runtime:actions:list
+  $ ./bin/run runtime:actions:ls
+  $ ./bin/run rt:action:list
+  $ ./bin/run rt:actions:list
+  $ ./bin/run rt:action:ls
+  $ ./bin/run rt:actions:ls
 ```
 
-_See code: [src/commands/runtime/action/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/action/list.js)_
+_See code: [src/commands/runtime/action/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/action/list.js)_
 
 ## `./bin/run runtime:action:update ACTIONNAME [ACTIONPATH]`
 
@@ -341,9 +370,12 @@ OPTIONS
 
   --web=true|yes|false|no|raw            treat ACTION as a web action or as a raw HTTP web action. web = true/yes|raw or
                                          web = false/no
+
+ALIASES
+  $ ./bin/run rt:action:update
 ```
 
-_See code: [src/commands/runtime/action/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/action/update.js)_
+_See code: [src/commands/runtime/action/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/action/update.js)_
 
 ## `./bin/run runtime:activation`
 
@@ -364,9 +396,12 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run rt:activation
 ```
 
-_See code: [src/commands/runtime/activation/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/activation/index.js)_
+_See code: [src/commands/runtime/activation/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/activation/index.js)_
 
 ## `./bin/run runtime:activation:get ACTIVATIONID`
 
@@ -387,9 +422,12 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run rt:activation:get
 ```
 
-_See code: [src/commands/runtime/activation/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/activation/get.js)_
+_See code: [src/commands/runtime/activation/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/activation/get.js)_
 
 ## `./bin/run runtime:activation:list [ACTIVATIONID]`
 
@@ -400,6 +438,7 @@ USAGE
   $ ./bin/run runtime:activation:list [ACTIVATIONID]
 
 OPTIONS
+  -f, --full               include full activation description
   -i, --insecure           bypass certificate check
 
   -l, --limit=limit        only return LIMIT number of activations from the collection with a maximum LIMIT of 200
@@ -432,9 +471,18 @@ OPTIONS
                            Jan 1970
 
   --version                Show version
+
+ALIASES
+  $ ./bin/run runtime:activations:list
+  $ ./bin/run runtime:activation:ls
+  $ ./bin/run runtime:activations:ls
+  $ ./bin/run rt:activation:list
+  $ ./bin/run rt:activation:ls
+  $ ./bin/run rt:activations:list
+  $ ./bin/run rt:activations:ls
 ```
 
-_See code: [src/commands/runtime/activation/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/activation/list.js)_
+_See code: [src/commands/runtime/activation/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/activation/list.js)_
 
 ## `./bin/run runtime:activation:logs ACTIVATIONID`
 
@@ -455,9 +503,14 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run runtime:activation:log
+  $ ./bin/run rt:activation:logs
+  $ ./bin/run rt:activation:log
 ```
 
-_See code: [src/commands/runtime/activation/logs.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/activation/logs.js)_
+_See code: [src/commands/runtime/activation/logs.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/activation/logs.js)_
 
 ## `./bin/run runtime:activation:result ACTIVATIONID`
 
@@ -478,9 +531,12 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run rt:activation:result
 ```
 
-_See code: [src/commands/runtime/activation/result.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/activation/result.js)_
+_See code: [src/commands/runtime/activation/result.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/activation/result.js)_
 
 ## `./bin/run runtime:deploy`
 
@@ -505,9 +561,12 @@ OPTIONS
   --key=key                    client key
   --param=param                parameter values in KEY VALUE format
   --version                    Show version
+
+ALIASES
+  $ ./bin/run rt:deploy
 ```
 
-_See code: [src/commands/runtime/deploy/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/deploy/index.js)_
+_See code: [src/commands/runtime/deploy/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/deploy/index.js)_
 
 ## `./bin/run runtime:deploy:export`
 
@@ -530,9 +589,12 @@ OPTIONS
   --key=key                  client key
   --projectname=projectname  (required) the name of the project to be undeployed
   --version                  Show version
+
+ALIASES
+  $ ./bin/run rt:deploy:export
 ```
 
-_See code: [src/commands/runtime/deploy/export.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/deploy/export.js)_
+_See code: [src/commands/runtime/deploy/export.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/deploy/export.js)_
 
 ## `./bin/run runtime:deploy:report`
 
@@ -555,9 +617,12 @@ OPTIONS
   --help                       Show help
   --key=key                    client key
   --version                    Show version
+
+ALIASES
+  $ ./bin/run rt:deploy:report
 ```
 
-_See code: [src/commands/runtime/deploy/report.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/deploy/report.js)_
+_See code: [src/commands/runtime/deploy/report.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/deploy/report.js)_
 
 ## `./bin/run runtime:deploy:sync`
 
@@ -580,9 +645,12 @@ OPTIONS
   --help                       Show help
   --key=key                    client key
   --version                    Show version
+
+ALIASES
+  $ ./bin/run rt:deploy:sync
 ```
 
-_See code: [src/commands/runtime/deploy/sync.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/deploy/sync.js)_
+_See code: [src/commands/runtime/deploy/sync.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/deploy/sync.js)_
 
 ## `./bin/run runtime:deploy:undeploy`
 
@@ -605,9 +673,12 @@ OPTIONS
   --key=key                  client key
   --projectname=projectname  the name of the project to be undeployed
   --version                  Show version
+
+ALIASES
+  $ ./bin/run rt:deploy:undeploy
 ```
 
-_See code: [src/commands/runtime/deploy/undeploy.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/deploy/undeploy.js)_
+_See code: [src/commands/runtime/deploy/undeploy.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/deploy/undeploy.js)_
 
 ## `./bin/run runtime:deploy:version`
 
@@ -628,9 +699,12 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run rt:deploy:version
 ```
 
-_See code: [src/commands/runtime/deploy/version.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/deploy/version.js)_
+_See code: [src/commands/runtime/deploy/version.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/deploy/version.js)_
 
 ## `./bin/run runtime:namespace`
 
@@ -651,9 +725,14 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run runtime:ns
+  $ ./bin/run rt:namespace
+  $ ./bin/run rt:ns
 ```
 
-_See code: [src/commands/runtime/namespace/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/namespace/index.js)_
+_See code: [src/commands/runtime/namespace/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/namespace/index.js)_
 
 ## `./bin/run runtime:namespace:get`
 
@@ -677,10 +756,14 @@ OPTIONS
   --version                Show version
 
 ALIASES
+  $ ./bin/run rt:get
   $ ./bin/run runtime:list
+  $ ./bin/run rt:list
+  $ ./bin/run runtime:ls
+  $ ./bin/run rt:ls
 ```
 
-_See code: [src/commands/runtime/namespace/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/namespace/get.js)_
+_See code: [src/commands/runtime/namespace/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/namespace/get.js)_
 
 ## `./bin/run runtime:namespace:list`
 
@@ -702,9 +785,18 @@ OPTIONS
   --json                   output raw json
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run runtime:namespace:ls
+  $ ./bin/run runtime:ns:list
+  $ ./bin/run runtime:ns:ls
+  $ ./bin/run rt:namespace:list
+  $ ./bin/run rt:namespace:ls
+  $ ./bin/run rt:ns:list
+  $ ./bin/run rt:ns:ls
 ```
 
-_See code: [src/commands/runtime/namespace/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/namespace/list.js)_
+_See code: [src/commands/runtime/namespace/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/namespace/list.js)_
 
 ## `./bin/run runtime:package`
 
@@ -725,9 +817,14 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run runtime:pkg
+  $ ./bin/run rt:package
+  $ ./bin/run rt:pkg
 ```
 
-_See code: [src/commands/runtime/package/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/package/index.js)_
+_See code: [src/commands/runtime/package/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/package/index.js)_
 
 ## `./bin/run runtime:package:bind PACKAGENAME BINDPACKAGENAME`
 
@@ -753,9 +850,14 @@ OPTIONS
   --json                                 output raw json
   --key=key                              client key
   --version                              Show version
+
+ALIASES
+  $ ./bin/run runtime:pkg:bind
+  $ ./bin/run rt:package:bind
+  $ ./bin/run rt:pkg:bind
 ```
 
-_See code: [src/commands/runtime/package/bind.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/package/bind.js)_
+_See code: [src/commands/runtime/package/bind.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/package/bind.js)_
 
 ## `./bin/run runtime:package:create PACKAGENAME`
 
@@ -782,9 +884,14 @@ OPTIONS
   --key=key                              client key
   --shared=true|yes|false|no             parameter to be passed to indicate whether package is shared or private
   --version                              Show version
+
+ALIASES
+  $ ./bin/run runtime:pkg:create
+  $ ./bin/run rt:package:create
+  $ ./bin/run rt:pkg:create
 ```
 
-_See code: [src/commands/runtime/package/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/package/create.js)_
+_See code: [src/commands/runtime/package/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/package/create.js)_
 
 ## `./bin/run runtime:package:delete PACKAGENAME`
 
@@ -796,9 +903,14 @@ USAGE
 
 OPTIONS
   --json  output raw json
+
+ALIASES
+  $ ./bin/run runtime:pkg:delete
+  $ ./bin/run rt:package:delete
+  $ ./bin/run rt:pkg:delete
 ```
 
-_See code: [src/commands/runtime/package/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/package/delete.js)_
+_See code: [src/commands/runtime/package/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/package/delete.js)_
 
 ## `./bin/run runtime:package:get PACKAGENAME`
 
@@ -819,9 +931,14 @@ OPTIONS
   --help                   Show help
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run runtime:pkg:get
+  $ ./bin/run rt:package:get
+  $ ./bin/run rt:pkg:get
 ```
 
-_See code: [src/commands/runtime/package/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/package/get.js)_
+_See code: [src/commands/runtime/package/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/package/get.js)_
 
 ## `./bin/run runtime:package:list [NAMESPACE]`
 
@@ -845,9 +962,18 @@ OPTIONS
   --json                   output raw json
   --key=key                client key
   --version                Show version
+
+ALIASES
+  $ ./bin/run runtime:package:ls
+  $ ./bin/run runtime:pkg:list
+  $ ./bin/run runtime:pkg:ls
+  $ ./bin/run rt:package:list
+  $ ./bin/run rt:package:ls
+  $ ./bin/run rt:pkg:list
+  $ ./bin/run rt:pkg:ls
 ```
 
-_See code: [src/commands/runtime/package/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/package/list.js)_
+_See code: [src/commands/runtime/package/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/package/list.js)_
 
 ## `./bin/run runtime:package:update PACKAGENAME`
 
@@ -874,9 +1000,14 @@ OPTIONS
   --key=key                              client key
   --shared=true|yes|false|no             parameter to be passed to indicate whether package is shared or private
   --version                              Show version
+
+ALIASES
+  $ ./bin/run runtime:pkg:update
+  $ ./bin/run rt:package:update
+  $ ./bin/run rt:pkg:update
 ```
 
-_See code: [src/commands/runtime/package/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/package/update.js)_
+_See code: [src/commands/runtime/package/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/package/update.js)_
 
 ## `./bin/run runtime:property`
 
@@ -897,9 +1028,13 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run runtime:prop
+  $ ./bin/run rt:prop
 ```
 
-_See code: [src/commands/runtime/property/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/property/index.js)_
+_See code: [src/commands/runtime/property/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/property/index.js)_
 
 ## `./bin/run runtime:property:get`
 
@@ -925,9 +1060,14 @@ OPTIONS
   --key           client key
   --namespace     whisk namespace
   --version       Show version
+
+ALIASES
+  $ ./bin/run runtime:prop:get
+  $ ./bin/run rt:property:get
+  $ ./bin/run rt:prop:get
 ```
 
-_See code: [src/commands/runtime/property/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/property/get.js)_
+_See code: [src/commands/runtime/property/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/property/get.js)_
 
 ## `./bin/run runtime:property:set`
 
@@ -949,9 +1089,14 @@ OPTIONS
   --key                  client key
   --namespace=namespace  whisk namespace
   --version              Show version
+
+ALIASES
+  $ ./bin/run runtime:prop:set
+  $ ./bin/run rt:property:set
+  $ ./bin/run rt:prop:set
 ```
 
-_See code: [src/commands/runtime/property/set.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/property/set.js)_
+_See code: [src/commands/runtime/property/set.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/property/set.js)_
 
 ## `./bin/run runtime:property:unset`
 
@@ -973,9 +1118,14 @@ OPTIONS
   --key           client key
   --namespace     whisk namespace
   --version       Show version
+
+ALIASES
+  $ ./bin/run runtime:prop:unset
+  $ ./bin/run rt:property:unset
+  $ ./bin/run rt:prop:unset
 ```
 
-_See code: [src/commands/runtime/property/unset.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/property/unset.js)_
+_See code: [src/commands/runtime/property/unset.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/property/unset.js)_
 
 ## `./bin/run runtime:route`
 
@@ -998,10 +1148,11 @@ OPTIONS
   --version       Show version
 
 ALIASES
-  $ ./bin/run api
+  $ ./bin/run runtime:api
+  $ ./bin/run rt:api
 ```
 
-_See code: [src/commands/runtime/route/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/route/index.js)_
+_See code: [src/commands/runtime/route/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/route/index.js)_
 
 ## `./bin/run runtime:route:create BASEPATH RELPATH APIVERB ACTION`
 
@@ -1044,10 +1195,12 @@ OPTIONS
   --version                                         Show version
 
 ALIASES
-  $ ./bin/run api:create
+  $ ./bin/run runtime:api:create
+  $ ./bin/run rt:route:create
+  $ ./bin/run rt:api:create
 ```
 
-_See code: [src/commands/runtime/route/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/route/create.js)_
+_See code: [src/commands/runtime/route/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/route/create.js)_
 
 ## `./bin/run runtime:route:delete BASEPATHORAPINAME [RELPATH] [APIVERB]`
 
@@ -1075,10 +1228,12 @@ OPTIONS
   --version       Show version
 
 ALIASES
-  $ ./bin/run api:delete
+  $ ./bin/run runtime:api:delete
+  $ ./bin/run rt:route:delete
+  $ ./bin/run rt:api:delete
 ```
 
-_See code: [src/commands/runtime/route/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/route/delete.js)_
+_See code: [src/commands/runtime/route/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/route/delete.js)_
 
 ## `./bin/run runtime:route:get BASEPATHORAPINAME`
 
@@ -1104,10 +1259,12 @@ OPTIONS
   --version       Show version
 
 ALIASES
-  $ ./bin/run api:get
+  $ ./bin/run runtime:api:get
+  $ ./bin/run rt:route:get
+  $ ./bin/run rt:api:get
 ```
 
-_See code: [src/commands/runtime/route/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/route/get.js)_
+_See code: [src/commands/runtime/route/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/route/get.js)_
 
 ## `./bin/run runtime:route:list [BASEPATH] [RELPATH] [APIVERB]`
 
@@ -1138,10 +1295,16 @@ OPTIONS
   --version          Show version
 
 ALIASES
-  $ ./bin/run api:list
+  $ ./bin/run runtime:route:ls
+  $ ./bin/run runtime:api:list
+  $ ./bin/run runtime:api:ls
+  $ ./bin/run rt:route:list
+  $ ./bin/run rt:route:ls
+  $ ./bin/run rt:api:list
+  $ ./bin/run rt:api:ls
 ```
 
-_See code: [src/commands/runtime/route/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/route/list.js)_
+_See code: [src/commands/runtime/route/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/route/list.js)_
 
 ## `./bin/run runtime:rule`
 
@@ -1162,9 +1325,12 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:rule
 ```
 
-_See code: [src/commands/runtime/rule/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/rule/index.js)_
+_See code: [src/commands/runtime/rule/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/rule/index.js)_
 
 ## `./bin/run runtime:rule:create NAME TRIGGER ACTION`
 
@@ -1191,9 +1357,12 @@ OPTIONS
   --json          output raw json
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:rule:create
 ```
 
-_See code: [src/commands/runtime/rule/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/rule/create.js)_
+_See code: [src/commands/runtime/rule/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/rule/create.js)_
 
 ## `./bin/run runtime:rule:delete NAME`
 
@@ -1217,9 +1386,12 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:rule:delete
 ```
 
-_See code: [src/commands/runtime/rule/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/rule/delete.js)_
+_See code: [src/commands/runtime/rule/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/rule/delete.js)_
 
 ## `./bin/run runtime:rule:disable NAME`
 
@@ -1243,9 +1415,12 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:rule:disable
 ```
 
-_See code: [src/commands/runtime/rule/disable.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/rule/disable.js)_
+_See code: [src/commands/runtime/rule/disable.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/rule/disable.js)_
 
 ## `./bin/run runtime:rule:enable NAME`
 
@@ -1269,9 +1444,12 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:rule:enable
 ```
 
-_See code: [src/commands/runtime/rule/enable.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/rule/enable.js)_
+_See code: [src/commands/runtime/rule/enable.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/rule/enable.js)_
 
 ## `./bin/run runtime:rule:get NAME`
 
@@ -1295,9 +1473,12 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:rule:get
 ```
 
-_See code: [src/commands/runtime/rule/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/rule/get.js)_
+_See code: [src/commands/runtime/rule/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/rule/get.js)_
 
 ## `./bin/run runtime:rule:list`
 
@@ -1321,9 +1502,14 @@ OPTIONS
   --json             output raw json
   --key              client key
   --version          Show version
+
+ALIASES
+  $ ./bin/run runtime:rule:ls
+  $ ./bin/run rt:rule:list
+  $ ./bin/run rt:rule:ls
 ```
 
-_See code: [src/commands/runtime/rule/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/rule/list.js)_
+_See code: [src/commands/runtime/rule/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/rule/list.js)_
 
 ## `./bin/run runtime:rule:status NAME`
 
@@ -1347,9 +1533,12 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:rule:status
 ```
 
-_See code: [src/commands/runtime/rule/status.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/rule/status.js)_
+_See code: [src/commands/runtime/rule/status.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/rule/status.js)_
 
 ## `./bin/run runtime:rule:update NAME TRIGGER ACTION`
 
@@ -1376,9 +1565,12 @@ OPTIONS
   --json          output raw json
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:rule:update
 ```
 
-_See code: [src/commands/runtime/rule/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/rule/update.js)_
+_See code: [src/commands/runtime/rule/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/rule/update.js)_
 
 ## `./bin/run runtime:trigger`
 
@@ -1399,9 +1591,12 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:trigger
 ```
 
-_See code: [src/commands/runtime/trigger/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/trigger/index.js)_
+_See code: [src/commands/runtime/trigger/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/trigger/index.js)_
 
 ## `./bin/run runtime:trigger:create TRIGGERNAME`
 
@@ -1429,9 +1624,12 @@ OPTIONS
   --help                                 Show help
   --key                                  client key
   --version                              Show version
+
+ALIASES
+  $ ./bin/run rt:trigger:create
 ```
 
-_See code: [src/commands/runtime/trigger/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/trigger/create.js)_
+_See code: [src/commands/runtime/trigger/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/trigger/create.js)_
 
 ## `./bin/run runtime:trigger:delete TRIGGERPATH`
 
@@ -1455,9 +1653,12 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:trigger:delete
 ```
 
-_See code: [src/commands/runtime/trigger/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/trigger/delete.js)_
+_See code: [src/commands/runtime/trigger/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/trigger/delete.js)_
 
 ## `./bin/run runtime:trigger:fire TRIGGERNAME`
 
@@ -1483,9 +1684,12 @@ OPTIONS
   --help                       Show help
   --key                        client key
   --version                    Show version
+
+ALIASES
+  $ ./bin/run rt:trigger:fire
 ```
 
-_See code: [src/commands/runtime/trigger/fire.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/trigger/fire.js)_
+_See code: [src/commands/runtime/trigger/fire.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/trigger/fire.js)_
 
 ## `./bin/run runtime:trigger:get TRIGGERPATH`
 
@@ -1509,9 +1713,12 @@ OPTIONS
   --help          Show help
   --key           client key
   --version       Show version
+
+ALIASES
+  $ ./bin/run rt:trigger:get
 ```
 
-_See code: [src/commands/runtime/trigger/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/trigger/get.js)_
+_See code: [src/commands/runtime/trigger/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/trigger/get.js)_
 
 ## `./bin/run runtime:trigger:list`
 
@@ -1535,9 +1742,14 @@ OPTIONS
   --json             output raw json
   --key              client key
   --version          Show version
+
+ALIASES
+  $ ./bin/run runtime:trigger:ls
+  $ ./bin/run rt:trigger:list
+  $ ./bin/run rt:trigger:ls
 ```
 
-_See code: [src/commands/runtime/trigger/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/trigger/list.js)_
+_See code: [src/commands/runtime/trigger/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/trigger/list.js)_
 
 ## `./bin/run runtime:trigger:update TRIGGERNAME`
 
@@ -1565,9 +1777,12 @@ OPTIONS
   --help                                 Show help
   --key                                  client key
   --version                              Show version
+
+ALIASES
+  $ ./bin/run rt:trigger:update
 ```
 
-_See code: [src/commands/runtime/trigger/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.0/src/commands/runtime/trigger/update.js)_
+_See code: [src/commands/runtime/trigger/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/v1.0.1/src/commands/runtime/trigger/update.js)_
 <!-- commandsstop -->
 
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint": "^6.0.0",
     "eslint-config-oclif": "^3.1.0",
     "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-import": "^2.13.10",
+    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.1.2",
     "eslint-plugin-node": "^9.0.0",
     "eslint-plugin-promise": "^4.0.0",

--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -16,6 +16,7 @@ const { createKeyValueObjectFromFlag, createKeyValueObjectFromFile, createCompon
 const { flags } = require('@oclif/command')
 
 class ActionCreate extends RuntimeBaseCommand {
+
   async run () {
     const { args, flags } = this.parse(ActionCreate)
     const name = args.actionName
@@ -198,5 +199,7 @@ ActionCreate.flags = {
 }
 
 ActionCreate.description = 'Creates an Action'
+
+ActionCreate.aliases = ['rt:action:create']
 
 module.exports = ActionCreate

--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -16,7 +16,6 @@ const { createKeyValueObjectFromFlag, createKeyValueObjectFromFile, createCompon
 const { flags } = require('@oclif/command')
 
 class ActionCreate extends RuntimeBaseCommand {
-
   async run () {
     const { args, flags } = this.parse(ActionCreate)
     const name = args.actionName

--- a/src/commands/runtime/action/delete.js
+++ b/src/commands/runtime/action/delete.js
@@ -44,7 +44,7 @@ ActionDelete.flags = {
 
 ActionDelete.description = 'Deletes an Action'
 
-ActionDelete.aliases = ['runtime:action:del', 
+ActionDelete.aliases = ['runtime:action:del',
   'rt:action:delete',
   'rt:action:del']
 

--- a/src/commands/runtime/action/delete.js
+++ b/src/commands/runtime/action/delete.js
@@ -44,4 +44,8 @@ ActionDelete.flags = {
 
 ActionDelete.description = 'Deletes an Action'
 
+ActionDelete.aliases = ['runtime:action:del', 
+  'rt:action:delete',
+  'rt:action:del']
+
 module.exports = ActionDelete

--- a/src/commands/runtime/action/get.js
+++ b/src/commands/runtime/action/get.js
@@ -99,4 +99,6 @@ ActionGet.flags = {
 
 ActionGet.description = 'Retrieves an Action'
 
+ActionGet.aliases = ['rt:action:get']
+
 module.exports = ActionGet

--- a/src/commands/runtime/action/index.js
+++ b/src/commands/runtime/action/index.js
@@ -22,4 +22,6 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Manage your actions'
 
+IndexCommand.aliases = ['rt:action']
+
 module.exports = IndexCommand

--- a/src/commands/runtime/action/invoke.js
+++ b/src/commands/runtime/action/invoke.js
@@ -83,4 +83,6 @@ ActionInvoke.flags = {
 }
 ActionInvoke.description = 'Invokes an Action'
 
+ActionInvoke.aliases = ['rt:action:invoke']
+
 module.exports = ActionInvoke

--- a/src/commands/runtime/action/list.js
+++ b/src/commands/runtime/action/list.js
@@ -70,4 +70,13 @@ ActionList.flags = {
 
 ActionList.description = 'Lists all the Actions'
 
+ActionList.aliases = [ 
+  'runtime:action:ls',
+  'runtime:actions:list',
+  'runtime:actions:ls',
+  'rt:action:list',
+  'rt:actions:list',
+  'rt:action:ls',
+  'rt:actions:ls']
+
 module.exports = ActionList

--- a/src/commands/runtime/action/list.js
+++ b/src/commands/runtime/action/list.js
@@ -70,7 +70,7 @@ ActionList.flags = {
 
 ActionList.description = 'Lists all the Actions'
 
-ActionList.aliases = [ 
+ActionList.aliases = [
   'runtime:action:ls',
   'runtime:actions:list',
   'runtime:actions:ls',

--- a/src/commands/runtime/action/update.js
+++ b/src/commands/runtime/action/update.js
@@ -206,4 +206,6 @@ ActionUpdate.flags = {
 
 ActionUpdate.description = 'Updates an Action'
 
+ActionUpdate.aliases = ['rt:action:update']
+
 module.exports = ActionUpdate

--- a/src/commands/runtime/activation/get.js
+++ b/src/commands/runtime/activation/get.js
@@ -34,5 +34,8 @@ ActivationGet.args = [
 ]
 
 ActivationGet.description = 'Retrieves an Activation'
+ActivationGet.aliases = [
+  'rt:activation:get'
+]
 
 module.exports = ActivationGet

--- a/src/commands/runtime/activation/index.js
+++ b/src/commands/runtime/activation/index.js
@@ -22,4 +22,6 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Manage your activations'
 
+IndexCommand.aliases = ['rt:activation']
+
 module.exports = IndexCommand

--- a/src/commands/runtime/activation/list.js
+++ b/src/commands/runtime/activation/list.js
@@ -152,4 +152,14 @@ ActivationList.flags = {
 
 ActivationList.description = 'Lists all the Activations'
 
+ActivationList.aliases = [
+  'runtime:activations:list',
+  'runtime:activation:ls',
+  'runtime:activations:ls',
+  'rt:activation:list',
+  'rt:activation:ls',
+  'rt:activations:list',
+  'rt:activations:ls'
+]
+
 module.exports = ActivationList

--- a/src/commands/runtime/activation/logs.js
+++ b/src/commands/runtime/activation/logs.js
@@ -35,4 +35,10 @@ ActivationLogs.args = [
 
 ActivationLogs.description = 'Retrieves the Logs for an Activation'
 
+ActivationLogs.aliases = [
+  'runtime:activation:log',
+  'rt:activation:logs',
+  'rt:activation:log'
+]
+
 module.exports = ActivationLogs

--- a/src/commands/runtime/activation/result.js
+++ b/src/commands/runtime/activation/result.js
@@ -35,4 +35,8 @@ ActivationResult.args = [
 
 ActivationResult.description = 'Retrieves the Results for an Activation'
 
+ActivationResult.aliases = [
+  'rt:activation:result'
+]
+
 module.exports = ActivationResult

--- a/src/commands/runtime/deploy/export.js
+++ b/src/commands/runtime/deploy/export.js
@@ -207,4 +207,8 @@ DeployExport.flags = {
 
 DeployExport.description = 'Exports managed project assets from Runtime to manifest and function files'
 
+DeployExport.aliases = [
+  'rt:deploy:export'
+]
+
 module.exports = DeployExport

--- a/src/commands/runtime/deploy/index.js
+++ b/src/commands/runtime/deploy/index.js
@@ -71,4 +71,6 @@ IndexCommand.flags = {
 
 IndexCommand.description = 'The Runtime Deployment Tool'
 
+IndexCommand.aliases = ['rt:deploy']
+
 module.exports = IndexCommand

--- a/src/commands/runtime/deploy/report.js
+++ b/src/commands/runtime/deploy/report.js
@@ -103,4 +103,6 @@ DeployReport.flags = {
 
 DeployReport.description = 'Provides a summary report of Runtime assets being deployed/undeployed based on manifest/deployment YAML'
 
+DeployReport.aliases = ['rt:deploy:report']
+
 module.exports = DeployReport

--- a/src/commands/runtime/deploy/sync.js
+++ b/src/commands/runtime/deploy/sync.js
@@ -188,4 +188,6 @@ DeploySync.flags = {
 
 DeploySync.description = 'A tool to sync deployment and undeployment of Runtime packages using a manifest and optional deployment files using YAML'
 
+DeploySync.aliases = ['rt:deploy:sync']
+
 module.exports = DeploySync

--- a/src/commands/runtime/deploy/undeploy.js
+++ b/src/commands/runtime/deploy/undeploy.js
@@ -132,4 +132,6 @@ DeployUndeploy.flags = {
 
 DeployUndeploy.description = 'Undeploy removes Runtime assets which were deployed from the manifest and deployment YAML'
 
+DeployUndeploy.aliases = ['rt:deploy:undeploy']
+
 module.exports = DeployUndeploy

--- a/src/commands/runtime/deploy/version.js
+++ b/src/commands/runtime/deploy/version.js
@@ -20,4 +20,6 @@ class DeployVersion extends RuntimeBaseCommand {
 
 DeployVersion.description = 'Prints the version number of aio runtime deploy'
 
+DeployVersion.aliases = ['rt:deploy:version']
+
 module.exports = DeployVersion

--- a/src/commands/runtime/index.js
+++ b/src/commands/runtime/index.js
@@ -22,4 +22,6 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Execute runtime commands'
 
+IndexCommand.aliases = ['rt']
+
 module.exports = IndexCommand

--- a/src/commands/runtime/namespace/get.js
+++ b/src/commands/runtime/namespace/get.js
@@ -90,8 +90,13 @@ NamespaceGet.flags = {
   })
 }
 
-NamespaceGet.aliases = [ 'runtime:list' ]
-
 NamespaceGet.description = 'Get triggers, actions, and rules in the registry for namespace'
+
+NamespaceGet.aliases = [
+  'rt:get',
+  'runtime:list',
+  'rt:list',
+  'runtime:ls',
+  'rt:ls' ]
 
 module.exports = NamespaceGet

--- a/src/commands/runtime/namespace/index.js
+++ b/src/commands/runtime/namespace/index.js
@@ -22,4 +22,6 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Manage your namespaces'
 
+IndexCommand.aliases = [ 'runtime:ns', 'rt:namespace', 'rt:ns']
+
 module.exports = IndexCommand

--- a/src/commands/runtime/namespace/index.js
+++ b/src/commands/runtime/namespace/index.js
@@ -22,6 +22,6 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Manage your namespaces'
 
-IndexCommand.aliases = [ 'runtime:ns', 'rt:namespace', 'rt:ns']
+IndexCommand.aliases = ['runtime:ns', 'rt:namespace', 'rt:ns']
 
 module.exports = IndexCommand

--- a/src/commands/runtime/namespace/list.js
+++ b/src/commands/runtime/namespace/list.js
@@ -47,4 +47,14 @@ NamespaceList.flags = {
 
 NamespaceList.description = 'Lists all of your namespaces for Adobe I/O Runtime'
 
+NamespaceList.aliases = [
+  'runtime:namespace:ls',
+  'runtime:ns:list',
+  'runtime:ns:ls',
+  'rt:namespace:list',
+  'rt:namespace:ls',
+  'rt:ns:list',
+  'rt:ns:ls'
+]
+
 module.exports = NamespaceList

--- a/src/commands/runtime/package/bind.js
+++ b/src/commands/runtime/package/bind.js
@@ -109,4 +109,10 @@ PackageBind.flags = {
 
 PackageBind.description = 'Bind parameters to a package'
 
+PackageBind.aliases = [
+  'runtime:pkg:bind',
+  'rt:package:bind',
+  'rt:pkg:bind'
+]
+
 module.exports = PackageBind

--- a/src/commands/runtime/package/create.js
+++ b/src/commands/runtime/package/create.js
@@ -111,4 +111,10 @@ PackageCreate.flags = {
 
 PackageCreate.description = 'Creates a Package'
 
+PackageCreate.aliases = [
+  'runtime:pkg:create',
+  'rt:package:create',
+  'rt:pkg:create'
+]
+
 module.exports = PackageCreate

--- a/src/commands/runtime/package/delete.js
+++ b/src/commands/runtime/package/delete.js
@@ -44,4 +44,10 @@ PackageDelete.flags = {
 
 PackageDelete.description = 'Deletes a Package'
 
+PackageDelete.aliases = [
+  'runtime:pkg:delete',
+  'rt:package:delete',
+  'rt:pkg:delete'
+]
+
 module.exports = PackageDelete

--- a/src/commands/runtime/package/get.js
+++ b/src/commands/runtime/package/get.js
@@ -36,4 +36,10 @@ PackageGet.args = [
 
 PackageGet.description = 'Retrieves a Package'
 
+PackageGet.aliases = [
+  'runtime:pkg:get',
+  'rt:package:get',
+  'rt:pkg:get'
+]
+
 module.exports = PackageGet

--- a/src/commands/runtime/package/index.js
+++ b/src/commands/runtime/package/index.js
@@ -22,4 +22,10 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Manage your packages'
 
+IndexCommand.aliases = [
+  'runtime:pkg',
+  'rt:package',
+  'rt:pkg'
+]
+
 module.exports = IndexCommand

--- a/src/commands/runtime/package/list.js
+++ b/src/commands/runtime/package/list.js
@@ -83,4 +83,14 @@ PackageList.args = [
 
 PackageList.description = 'Lists all the Packages'
 
+PackageList.aliases = [
+  'runtime:package:ls',
+  'runtime:pkg:list',
+  'runtime:pkg:ls',
+  'rt:package:list',
+  'rt:package:ls',
+  'rt:pkg:list',
+  'rt:pkg:ls'
+]
+
 module.exports = PackageList

--- a/src/commands/runtime/package/update.js
+++ b/src/commands/runtime/package/update.js
@@ -114,4 +114,10 @@ PackageUpdate.flags = {
 
 PackageUpdate.description = 'Updates a Package'
 
+PackageUpdate.aliases = [
+  'runtime:pkg:update',
+  'rt:package:update',
+  'rt:pkg:update'
+]
+
 module.exports = PackageUpdate

--- a/src/commands/runtime/property/get.js
+++ b/src/commands/runtime/property/get.js
@@ -126,4 +126,10 @@ PropertyGet.flags = {
 
 PropertyGet.description = 'get property'
 
+PropertyGet.aliases = [
+  'runtime:prop:get',
+  'rt:property:get',
+  'rt:prop:get'
+]
+
 module.exports = PropertyGet

--- a/src/commands/runtime/property/index.js
+++ b/src/commands/runtime/property/index.js
@@ -22,4 +22,9 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Execute property commands'
 
+IndexCommand.aliases = [
+  'runtime:prop',
+  'rt:prop'
+]
+
 module.exports = IndexCommand

--- a/src/commands/runtime/property/set.js
+++ b/src/commands/runtime/property/set.js
@@ -60,4 +60,10 @@ PropertySet.flags = {
 
 PropertySet.description = 'set property'
 
+PropertySet.aliases = [
+  'runtime:prop:set',
+  'rt:property:set',
+  'rt:prop:set'
+]
+
 module.exports = PropertySet

--- a/src/commands/runtime/property/unset.js
+++ b/src/commands/runtime/property/unset.js
@@ -64,4 +64,10 @@ PropertyUnset.flags = {
 
 PropertyUnset.description = 'unset property'
 
+PropertyUnset.aliases = [
+  'runtime:prop:unset',
+  'rt:property:unset',
+  'rt:prop:unset'
+]
+
 module.exports = PropertyUnset

--- a/src/commands/runtime/route/create.js
+++ b/src/commands/runtime/route/create.js
@@ -76,7 +76,9 @@ RouteCreate.flags = {
 RouteCreate.description = 'create a new api route'
 
 RouteCreate.aliases = [
-  'api:create'
+  'runtime:api:create',
+  'rt:route:create',
+  'rt:api:create'
 ]
 
 module.exports = RouteCreate

--- a/src/commands/runtime/route/delete.js
+++ b/src/commands/runtime/route/delete.js
@@ -58,7 +58,9 @@ RouteDelete.flags = {
 RouteDelete.description = 'delete an API'
 
 RouteDelete.aliases = [
-  'api:delete'
+  'runtime:api:delete',
+  'rt:route:delete',
+  'rt:api:delete'
 ]
 
 module.exports = RouteDelete

--- a/src/commands/runtime/route/get.js
+++ b/src/commands/runtime/route/get.js
@@ -46,7 +46,9 @@ RouteGet.flags = {
 RouteGet.description = 'get API details'
 
 RouteGet.aliases = [
-  'api:get'
+  'runtime:api:get',
+  'rt:route:get',
+  'rt:api:get'
 ]
 
 module.exports = RouteGet

--- a/src/commands/runtime/route/index.js
+++ b/src/commands/runtime/route/index.js
@@ -23,7 +23,8 @@ class IndexCommand extends RuntimeBaseCommand {
 IndexCommand.description = 'Manage your routes'
 
 IndexCommand.aliases = [
-  'api'
+  'runtime:api',
+  'rt:api'
 ]
 
 module.exports = IndexCommand

--- a/src/commands/runtime/route/list.js
+++ b/src/commands/runtime/route/list.js
@@ -121,7 +121,13 @@ RouteList.flags = {
 RouteList.description = 'list route/apis for Adobe I/O Runtime'
 
 RouteList.aliases = [
-  'api:list'
+  'runtime:route:ls',
+  'runtime:api:list',
+  'runtime:api:ls',
+  'rt:route:list',
+  'rt:route:ls',
+  'rt:api:list',
+  'rt:api:ls'
 ]
 
 module.exports = RouteList

--- a/src/commands/runtime/rule/create.js
+++ b/src/commands/runtime/rule/create.js
@@ -55,4 +55,8 @@ RuleCreate.flags = {
   })
 }
 
+RuleCreate.aliases = [
+  'rt:rule:create'
+]
+
 module.exports = RuleCreate

--- a/src/commands/runtime/rule/delete.js
+++ b/src/commands/runtime/rule/delete.js
@@ -39,4 +39,8 @@ RuleDelete.flags = {
   ...RuntimeBaseCommand.flags
 }
 
+RuleDelete.aliases = [
+  'rt:rule:delete'
+]
+
 module.exports = RuleDelete

--- a/src/commands/runtime/rule/disable.js
+++ b/src/commands/runtime/rule/disable.js
@@ -39,4 +39,8 @@ RuleDisable.flags = {
   ...RuntimeBaseCommand.flags
 }
 
+RuleDisable.aliases = [
+  'rt:rule:disable'
+]
+
 module.exports = RuleDisable

--- a/src/commands/runtime/rule/enable.js
+++ b/src/commands/runtime/rule/enable.js
@@ -39,4 +39,8 @@ RuleEnable.flags = {
   ...RuntimeBaseCommand.flags
 }
 
+RuleEnable.aliases = [
+  'rt:rule:enable'
+]
+
 module.exports = RuleEnable

--- a/src/commands/runtime/rule/get.js
+++ b/src/commands/runtime/rule/get.js
@@ -39,4 +39,8 @@ RuleGet.flags = {
   ...RuntimeBaseCommand.flags
 }
 
+RuleGet.aliases = [
+  'rt:rule:get'
+]
+
 module.exports = RuleGet

--- a/src/commands/runtime/rule/index.js
+++ b/src/commands/runtime/rule/index.js
@@ -22,4 +22,8 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Manage your rules'
 
+IndexCommand.aliases = [
+  'rt:rule'
+]
+
 module.exports = IndexCommand

--- a/src/commands/runtime/rule/list.js
+++ b/src/commands/runtime/rule/list.js
@@ -81,4 +81,10 @@ RuleList.flags = {
   })
 }
 
+RuleList.aliases = [
+  'runtime:rule:ls',
+  'rt:rule:list',
+  'rt:rule:ls'
+]
+
 module.exports = RuleList

--- a/src/commands/runtime/rule/status.js
+++ b/src/commands/runtime/rule/status.js
@@ -39,4 +39,8 @@ RuleStatus.flags = {
   ...RuntimeBaseCommand.flags
 }
 
+RuleStatus.aliases = [
+  'rt:rule:status'
+]
+
 module.exports = RuleStatus

--- a/src/commands/runtime/rule/update.js
+++ b/src/commands/runtime/rule/update.js
@@ -55,4 +55,8 @@ RuleUpdate.flags = {
   })
 }
 
+RuleUpdate.aliases = [
+  'rt:rule:update'
+]
+
 module.exports = RuleUpdate

--- a/src/commands/runtime/trigger/create.js
+++ b/src/commands/runtime/trigger/create.js
@@ -101,4 +101,8 @@ TriggerCreate.flags = {
 
 TriggerCreate.description = 'Create a trigger for Adobe I/O Runtime'
 
+TriggerCreate.aliases = [
+  'rt:trigger:create'
+]
+
 module.exports = TriggerCreate

--- a/src/commands/runtime/trigger/delete.js
+++ b/src/commands/runtime/trigger/delete.js
@@ -43,4 +43,8 @@ TriggerDelete.flags = {
 
 TriggerDelete.description = 'Get a trigger for Adobe I/O Runtime'
 
+TriggerDelete.aliases = [
+  'rt:trigger:delete'
+]
+
 module.exports = TriggerDelete

--- a/src/commands/runtime/trigger/fire.js
+++ b/src/commands/runtime/trigger/fire.js
@@ -76,4 +76,8 @@ TriggerFire.flags = {
 
 TriggerFire.description = 'Fire a trigger for Adobe I/O Runtime'
 
+TriggerFire.aliases = [
+  'rt:trigger:fire'
+]
+
 module.exports = TriggerFire

--- a/src/commands/runtime/trigger/get.js
+++ b/src/commands/runtime/trigger/get.js
@@ -44,4 +44,8 @@ TriggerGet.args = [
 
 TriggerGet.description = 'Get a trigger for Adobe I/O Runtime'
 
+TriggerGet.aliases = [
+  'rt:trigger:get'
+]
+
 module.exports = TriggerGet

--- a/src/commands/runtime/trigger/index.js
+++ b/src/commands/runtime/trigger/index.js
@@ -22,4 +22,8 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Manage your triggers'
 
+IndexCommand.aliases = [
+  'rt:trigger'
+]
+
 module.exports = IndexCommand

--- a/src/commands/runtime/trigger/list.js
+++ b/src/commands/runtime/trigger/list.js
@@ -69,4 +69,10 @@ TriggerList.flags = {
 
 TriggerList.description = 'Lists all of your triggers for Adobe I/O Runtime'
 
+TriggerList.aliases = [
+  'runtime:trigger:ls',
+  'rt:trigger:list',
+  'rt:trigger:ls'
+]
+
 module.exports = TriggerList

--- a/src/commands/runtime/trigger/update.js
+++ b/src/commands/runtime/trigger/update.js
@@ -101,4 +101,8 @@ TriggerUpdate.flags = {
 
 TriggerUpdate.description = 'Update or create a trigger for Adobe I/O Runtime'
 
+TriggerUpdate.aliases = [
+  'rt:trigger:update'
+]
+
 module.exports = TriggerUpdate

--- a/test/commands/runtime/action/create.test.js
+++ b/test/commands/runtime/action/create.test.js
@@ -25,10 +25,6 @@ test('description', async () => {
   expect(TheCommand.description).toBeDefined()
 })
 
-test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
-})
-
 test('flags', async () => {
   expect(TheCommand.flags.param.required).toBe(false)
   expect(TheCommand.flags.param.hidden).toBe(false)
@@ -88,6 +84,12 @@ test('args', async () => {
   expect(actionPath.name).toBeDefined()
   expect(actionPath.name).toEqual('actionPath')
   expect(actionPath.required).toEqual(false)
+})
+
+test('aliases', async () => {
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 describe('instance methods', () => {

--- a/test/commands/runtime/action/delete.test.js
+++ b/test/commands/runtime/action/delete.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/action/get.test.js
+++ b/test/commands/runtime/action/get.test.js
@@ -27,7 +27,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/action/index.test.js
+++ b/test/commands/runtime/action/index.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/action/invoke.test.js
+++ b/test/commands/runtime/action/invoke.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/action/list.test.js
+++ b/test/commands/runtime/action/list.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/action/update.test.js
+++ b/test/commands/runtime/action/update.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/activation/get.test.js
+++ b/test/commands/runtime/activation/get.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/activation/index.test.js
+++ b/test/commands/runtime/activation/index.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/activation/list.test.js
+++ b/test/commands/runtime/activation/list.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/activation/logs.test.js
+++ b/test/commands/runtime/activation/logs.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/activation/result.test.js
+++ b/test/commands/runtime/activation/result.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/deploy/export.test.js
+++ b/test/commands/runtime/deploy/export.test.js
@@ -29,7 +29,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 describe('instance methods', () => {

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -30,7 +30,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/deploy/report.test.js
+++ b/test/commands/runtime/deploy/report.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/deploy/sync.test.js
+++ b/test/commands/runtime/deploy/sync.test.js
@@ -35,7 +35,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 describe('instance methods', () => {

--- a/test/commands/runtime/deploy/undeploy.test.js
+++ b/test/commands/runtime/deploy/undeploy.test.js
@@ -30,7 +30,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/deploy/version.test.js
+++ b/test/commands/runtime/deploy/version.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 describe('instance methods', () => {

--- a/test/commands/runtime/index.test.js
+++ b/test/commands/runtime/index.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/namespace/get.test.js
+++ b/test/commands/runtime/namespace/get.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual(['runtime:list'])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/namespace/index.test.js
+++ b/test/commands/runtime/namespace/index.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/namespace/list.test.js
+++ b/test/commands/runtime/namespace/list.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/package/bind.test.js
+++ b/test/commands/runtime/package/bind.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/package/create.test.js
+++ b/test/commands/runtime/package/create.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/package/delete.test.js
+++ b/test/commands/runtime/package/delete.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/package/get.test.js
+++ b/test/commands/runtime/package/get.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/package/index.test.js
+++ b/test/commands/runtime/package/index.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/package/list.test.js
+++ b/test/commands/runtime/package/list.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/package/update.test.js
+++ b/test/commands/runtime/package/update.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/property/get.test.js
+++ b/test/commands/runtime/property/get.test.js
@@ -27,7 +27,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/property/index.test.js
+++ b/test/commands/runtime/property/index.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/property/set.test.js
+++ b/test/commands/runtime/property/set.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/property/unset.test.js
+++ b/test/commands/runtime/property/unset.test.js
@@ -23,7 +23,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/route/create.test.js
+++ b/test/commands/runtime/route/create.test.js
@@ -27,6 +27,8 @@ test('description', async () => {
 
 test('aliases', async () => {
   expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/route/delete.test.js
+++ b/test/commands/runtime/route/delete.test.js
@@ -27,6 +27,8 @@ test('description', async () => {
 
 test('aliases', async () => {
   expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/route/get.test.js
+++ b/test/commands/runtime/route/get.test.js
@@ -27,6 +27,8 @@ test('description', async () => {
 
 test('aliases', async () => {
   expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/route/index.test.js
+++ b/test/commands/runtime/route/index.test.js
@@ -25,6 +25,8 @@ test('description', async () => {
 
 test('aliases', async () => {
   expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/route/list.test.js
+++ b/test/commands/runtime/route/list.test.js
@@ -27,6 +27,8 @@ test('description', async () => {
 
 test('aliases', async () => {
   expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/rule/create.test.js
+++ b/test/commands/runtime/rule/create.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/rule/delete.test.js
+++ b/test/commands/runtime/rule/delete.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/rule/disable.test.js
+++ b/test/commands/runtime/rule/disable.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/rule/enable.test.js
+++ b/test/commands/runtime/rule/enable.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/rule/get.test.js
+++ b/test/commands/runtime/rule/get.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/rule/index.test.js
+++ b/test/commands/runtime/rule/index.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/rule/list.test.js
+++ b/test/commands/runtime/rule/list.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('base flags included in command flags',

--- a/test/commands/runtime/rule/status.test.js
+++ b/test/commands/runtime/rule/status.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/rule/update.test.js
+++ b/test/commands/runtime/rule/update.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/trigger/create.test.js
+++ b/test/commands/runtime/trigger/create.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('base flags included in command flags',

--- a/test/commands/runtime/trigger/delete.test.js
+++ b/test/commands/runtime/trigger/delete.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/trigger/fire.test.js
+++ b/test/commands/runtime/trigger/fire.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/trigger/get.test.js
+++ b/test/commands/runtime/trigger/get.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/trigger/index.test.js
+++ b/test/commands/runtime/trigger/index.test.js
@@ -24,7 +24,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {

--- a/test/commands/runtime/trigger/list.test.js
+++ b/test/commands/runtime/trigger/list.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('args', async () => {

--- a/test/commands/runtime/trigger/update.test.js
+++ b/test/commands/runtime/trigger/update.test.js
@@ -26,7 +26,9 @@ test('description', async () => {
 })
 
 test('aliases', async () => {
-  expect(TheCommand.aliases).toEqual([])
+  expect(TheCommand.aliases).toBeDefined()
+  expect(TheCommand.aliases).toBeInstanceOf(Array)
+  expect(TheCommand.aliases.length).toBeGreaterThan(0)
 })
 
 test('flags', async () => {


### PR DESCRIPTION
- added `rt` alias to all subcommands
- all subcommands with `list` will also accept `ls`
- all subcommands with `select` will also accept `sel`
- all `namespace` subcommands also accept `ns`
- all `package` subcommands also accept `pkg`
- all `property` subcommands also accept `prop`

- added some plural aliases where it made sense
  `aio rt actions ls`
  `aio rt activations ls`

- tests throughout, only tests alias length > 0

This closes #34