### PR TITLE
[ACNA-290] Set custom useragent for calls to openwhisk rest api

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cli-ux": "^5.2.0",
     "js-yaml": "^3.13.1",
     "node-fetch": "^2.3.0",
-    "openwhisk": "^3.19.0",
+    "openwhisk": "^3.20.0",
     "properties-reader": "0.3.0",
     "sha1": "^1.1.1"
   },

--- a/src/RuntimeBaseCommand.js
+++ b/src/RuntimeBaseCommand.js
@@ -53,6 +53,12 @@ class RuntimeBaseCommand extends Command {
       throw new Error('An AUTH key must be specified')
     }
 
+    // .env var is given priority, then the flag, which has a default value
+    // of aio-cli-plugin-runtime@VERSION
+    if (!process.env['__OW_USER_AGENT']) {
+      process.env['__OW_USER_AGENT'] = flags.useragent
+    }
+
     return OpenWhisk(options)
   }
 
@@ -130,7 +136,12 @@ RuntimeBaseCommand.flags = {
   debug: flags.string({ description: 'Debug level output' }),
   verbose: flags.boolean({ char: 'v', description: 'Verbose output' }),
   version: flags.boolean({ description: 'Show version' }),
-  help: flags.boolean({ description: 'Show help' })
+  help: flags.boolean({ description: 'Show help' }),
+  useragent: flags.string({
+    hidden: true,
+    description: 'Use custom user-agent string',
+    default: 'aio-cli-plugin-runtime@' + require('../package.json').version
+  })
 }
 
 module.exports = RuntimeBaseCommand

--- a/test/RuntimeBaseCommand.test.js
+++ b/test/RuntimeBaseCommand.test.js
@@ -34,7 +34,8 @@ test('aliases', async () => {
 })
 
 test('flags', async () => {
-  expect(Object.keys(TheCommand.flags)).toEqual(['cert', 'key', 'apiversion', 'apihost', 'auth', 'insecure', 'debug', 'verbose', 'version', 'help'])
+  expect(Object.keys(TheCommand.flags)).toEqual(expect.arrayContaining(
+    ['cert', 'key', 'apiversion', 'apihost', 'auth', 'insecure', 'debug', 'verbose', 'version', 'help', 'useragent']))
 })
 
 test('args', async () => {

--- a/test/commands/runtime/action/list.test.js
+++ b/test/commands/runtime/action/list.test.js
@@ -16,27 +16,43 @@ const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand.js')
 const ow = require('openwhisk')()
 const owAction = 'actions.list'
 
-test('exports', async () => {
-  expect(typeof TheCommand).toEqual('function')
-  expect(TheCommand.prototype instanceof RuntimeBaseCommand).toBeTruthy()
-})
+describe('List command meta', () => {
+  test('exports', async () => {
+    expect(typeof TheCommand).toEqual('function')
+    expect(TheCommand.prototype instanceof RuntimeBaseCommand).toBeTruthy()
+  })
 
-test('description', async () => {
-  expect(TheCommand.description).toBeDefined()
-})
+  test('description', async () => {
+    expect(TheCommand.description).toBeDefined()
+  })
 
-test('aliases', async () => {
-  expect(TheCommand.aliases).toBeDefined()
-  expect(TheCommand.aliases).toBeInstanceOf(Array)
-  expect(TheCommand.aliases.length).toBeGreaterThan(0)
-})
+  test('aliases', async () => {
+    expect(TheCommand.aliases).toBeDefined()
+    expect(TheCommand.aliases).toBeInstanceOf(Array)
+    expect(TheCommand.aliases.length).toBeGreaterThan(0)
+  })
 
-test('flags', async () => {
-  expect(TheCommand.flags).toMatchObject({ limit: { char: 'l', description: 'only return LIMIT number of actions from the collection (default 30)', hidden: false, multiple: false, required: false }, skip: { char: 's', description: 'exclude the first SKIP number of actions from the result', multiple: false, required: false } })
-})
+  test('flags', async () => {
+    expect(TheCommand.flags).toMatchObject({
+      limit: {
+        char: 'l',
+        description: expect.any(String),
+        hidden: false,
+        multiple: false,
+        required: false
+      },
+      skip: {
+        char: 's',
+        description: expect.any(String),
+        multiple: false,
+        required: false
+      }
+    })
+  })
 
-test('args', async () => {
-  expect(TheCommand.args).toBeUndefined()
+  test('args', async () => {
+    expect(TheCommand.args).toBeUndefined()
+  })
 })
 
 describe('instance methods', () => {
@@ -57,7 +73,7 @@ describe('instance methods', () => {
       command.argv = ['--limit', '1']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ limit: 1 })
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({ limit: 1 }))
           expect(stdout.output).toMatchFixture('action/list-output.txt')
         })
     })
@@ -98,8 +114,8 @@ describe('instance methods', () => {
       command.argv = ['--skip', '3']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ skip: 3 })
-          expect(stdout.output).toMatch('actions                                           ')
+          expect(cmd).toHaveBeenCalledWith({ skip: 3, useragent: expect.any(String) })
+          expect(stdout.output).toMatch('actions')
         })
     })
 

--- a/test/commands/runtime/action/list.test.js
+++ b/test/commands/runtime/action/list.test.js
@@ -114,7 +114,7 @@ describe('instance methods', () => {
       command.argv = ['--skip', '3']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ skip: 3, useragent: expect.any(String) })
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({ skip: 3 }))
           expect(stdout.output).toMatch('actions')
         })
     })

--- a/test/commands/runtime/rule/list.test.js
+++ b/test/commands/runtime/rule/list.test.js
@@ -72,7 +72,7 @@ describe('instance methods', () => {
       command.argv = ['--limit', '2', '--json']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ limit: 2, json: true })
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({ limit: 2, json: true }))
           expect(cmd2).toHaveBeenCalled()
           expect(stdout.output).toMatchFixture('rule/list.json')
         })
@@ -94,7 +94,7 @@ describe('instance methods', () => {
       command.argv = ['--skip', '3', '--json']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ limit: 30, skip: 3, json: true })
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({ limit: 30, skip: 3, json: true }))
           expect(stdout.output).toMatch('[]')
         })
     })
@@ -105,7 +105,7 @@ describe('instance methods', () => {
       command.argv = ['--limit', '2']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ limit: 2 })
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({ limit: 2 }))
           expect(cmd2).toHaveBeenCalled()
           expect(stdout.output.replace(/\s/g, '')).toMatchFixture('rule/list-output.txt')
         })
@@ -117,7 +117,7 @@ describe('instance methods', () => {
       command.argv = ['--limit', '2']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ limit: 2 })
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({ limit: 2 }))
           expect(cmd2).toHaveBeenCalled()
           expect(stdout.output.replace(/\s/g, '')).toMatchFixture('rule/list-output-public.txt')
         })


### PR DESCRIPTION
update openwhisk dep to latest which includes __OW_USER_AGENT env var…, 
add flag to override our default ua

<!--- Provide a general summary of your changes in the Title above -->

## Description

added a flag so this can be overridden, otherwise you get our default
`aio runtime action list --useragent my-user-agent-string`

if an environment var of __OW_USER_AGENT is already present, it will be used, and the flag will be ignored.

flag is hidden, do we want to show it?


## How Has This Been Tested?

manually tested by running with `DEBUG=needle` which shows all whisk api calls
added tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
