### PR TITLE
compare fixture without whitespace

### DIFF
--- a/src/commands/runtime/action/list.js
+++ b/src/commands/runtime/action/list.js
@@ -34,6 +34,7 @@ class ActionList extends RuntimeBaseCommand {
           },
           published: {
             header: '',
+            minWidth: 7,
             get: row => `${row.publish === false ? 'private' : 'public'}`
           },
           details: {

--- a/src/commands/runtime/namespace/get.js
+++ b/src/commands/runtime/namespace/get.js
@@ -25,7 +25,7 @@ function createColumns (columnName) {
     published: {
       header: '',
       'no-truncate': true,
-      minWidth: 7,
+      minWidth: 10,
       get: row => `${row.publish === false ? 'private' : 'public'}`
     },
     exec: {

--- a/src/commands/runtime/namespace/get.js
+++ b/src/commands/runtime/namespace/get.js
@@ -25,6 +25,7 @@ function createColumns (columnName) {
     published: {
       header: '',
       'no-truncate': true,
+      minWidth: 7,
       get: row => `${row.publish === false ? 'private' : 'public'}`
     },
     exec: {

--- a/src/commands/runtime/namespace/get.js
+++ b/src/commands/runtime/namespace/get.js
@@ -25,7 +25,7 @@ function createColumns (columnName) {
     published: {
       header: '',
       'no-truncate': true,
-      minWidth: 10,
+      minWidth: 8,
       get: row => `${row.publish === false ? 'private' : 'public'}`
     },
     exec: {

--- a/src/commands/runtime/package/list.js
+++ b/src/commands/runtime/package/list.js
@@ -44,6 +44,7 @@ class PackageList extends RuntimeBaseCommand {
           },
           published: {
             header: '',
+            minWidth: 7,
             get: row => `${row.publish === false ? 'private' : 'public'}`
           }
         }

--- a/src/commands/runtime/trigger/list.js
+++ b/src/commands/runtime/trigger/list.js
@@ -43,6 +43,7 @@ class TriggerList extends RuntimeBaseCommand {
           },
           published: {
             header: '',
+            minWidth: 7,
             get: row => `${row.publish === false ? 'private' : 'public'}`
           }
         }

--- a/test/commands/runtime/namespace/get.test.js
+++ b/test/commands/runtime/namespace/get.test.js
@@ -69,8 +69,7 @@ describe('instance methods', () => {
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalled()
-          // todo: now skip testing formatted output which can vary
-          // expect(stdout.output).toMatchFixture('namespace/get.txt')
+          expect(stdout.output).toMatchFixtureIgnoreWhite('namespace/get.txt')
           done()
         })
     })
@@ -124,9 +123,7 @@ describe('instance methods', () => {
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalled()
-          // todo: skip testing formatted output which can vary
-          // todo: expect(eol.auto(received).replace(/\s/g, '')).toEqual(eol.auto(val).replace(/\s/g, ''))
-          // expect(stdout.output).toMatchFixture('namespace/get-name-sort.txt')
+          expect(stdout.output).toMatchFixtureIgnoreWhite('namespace/get-name-sort.txt')
           done()
         })
     })

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -119,6 +119,20 @@ expect.extend({
   }
 })
 
+// clean trailing whitespace which will vary with different terminal settings
+function cleanWhite (input) {
+  return eol.split(input).map(line => { return line.trim() }).join(eol.auto)
+}
+
+expect.extend({
+  toMatchFixtureIgnoreWhite (received, argument) {
+    const val = cleanWhite(fixtureFile(argument))
+    // eat white
+    expect(cleanWhite(received)).toEqual(val)
+    return { pass: true }
+  }
+})
+
 expect.extend({
   toMatchFixtureJson (received, argument) {
     const val = fixtureJson(argument)


### PR DESCRIPTION
We were skipping some tests because the output varied with different terminals.
This removes whitespace from the equation.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
