### PR TITLE
Remove dep with pin for memfs@2.15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "jest": "^24.9.0",
     "jest-junit": "^9.0.0",
     "jest-plugin-fs": "^2.9.0",
-    "memfs": "2.15.5",
     "stdout-stderr": "^0.1.9"
   },
   "engines": {


### PR DESCRIPTION
## Description

 memfs@2.16.1 was released that patches the issue.

(this is a dep from jest-plugin-fs)

Closes #59

## Motivation and Context

Cleanup a workaround

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
