### PR TITLE
Save file to appropriately named file based on action kind ignoring package name.

### DIFF
--- a/src/commands/runtime/action/get.js
+++ b/src/commands/runtime/action/get.js
@@ -55,12 +55,12 @@ class ActionGet extends RuntimeBaseCommand {
 
         if (flags.save || bSaveFile) {
           if (result.exec.binary) {
-            const saveFileName = bSaveFile ? flags['save-as'] : `${name}.zip`
+            const saveFileName = bSaveFile ? flags['save-as'] : `${result.name}.zip`
             const data = Buffer.from(result.exec.code, 'base64')
             fs.writeFileSync(saveFileName, data, 'buffer')
           } else {
             const extension = fileExtensionForKind(result.exec.kind)
-            const saveFileName = bSaveFile ? flags['save-as'] : `${name}${extension}`
+            const saveFileName = bSaveFile ? flags['save-as'] : `${result.name}${extension}`
             fs.writeFileSync(saveFileName, result.exec.code)
           }
         } else {

--- a/src/commands/runtime/action/get.js
+++ b/src/commands/runtime/action/get.js
@@ -10,9 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
-const { flags } = require('@oclif/command')
 const fs = require('fs')
+const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
+const { fileExtensionForKind } = require('../../../runtime-helpers')
+const { flags } = require('@oclif/command')
 
 class ActionGet extends RuntimeBaseCommand {
   async run () {
@@ -58,7 +59,8 @@ class ActionGet extends RuntimeBaseCommand {
             const data = Buffer.from(result.exec.code, 'base64')
             fs.writeFileSync(saveFileName, data, 'buffer')
           } else {
-            const saveFileName = bSaveFile ? flags['save-as'] : `${name}.js`
+            const extension = fileExtensionForKind(result.exec.kind)
+            const saveFileName = bSaveFile ? flags['save-as'] : `${name}${extension}`
             fs.writeFileSync(saveFileName, result.exec.code)
           }
         } else {

--- a/test/__fixtures__/action/getpackage.json
+++ b/test/__fixtures__/action/getpackage.json
@@ -1,0 +1,32 @@
+{
+  "annotations": [
+    {
+      "key": "web-export",
+      "value": true
+    },
+    {
+      "key": "raw-http",
+      "value": true
+    },
+    {
+      "key": "exec",
+      "value": "nodejs:10-fat"
+    }
+  ],
+  "exec": {
+    "binary": false,
+    "kind": "nodejs:10-fat",
+    "code":"this is the code"
+  },
+  "limits": {
+    "concurrency": 1,
+    "logs": 10,
+    "memory": 256,
+    "timeout": 60000
+  },
+  "name": "hello",
+  "namespace": "53444_41603/pkg",
+  "publish": false,
+  "updated": 1549408742750,
+  "version": "0.0.2"
+}

--- a/test/commands/runtime/action/get.test.js
+++ b/test/commands/runtime/action/get.test.js
@@ -149,6 +149,17 @@ describe('instance methods', () => {
         })
     })
 
+    test('retrieve an action in a package --save', () => {
+      fs.writeFileSync = jest.fn()
+      const cmd = ow.mockResolvedFixture(owAction, 'action/getpackage.json')
+      command.argv = ['pkg/hello', '--save']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith('pkg/hello')
+          expect(fs.writeFileSync).toHaveBeenCalledWith('hello.js', 'this is the code')
+        })
+    })
+
     test('retrieve an action --save-as', () => {
       const cmd = ow.mockResolvedFixture(owAction, 'action/get.json')
       fs.writeFileSync = jest.fn()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Save file for package action correctly by stripping package name from filename.
Save file to appropriately named file based on action kind.
Add helpers to map from file names to kinds and vice versa.

## Related Issue
Closes #65 .

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
