### PR TITLE
Allow action update without a code artifact.

### DIFF
--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -12,98 +12,139 @@ governing permissions and limitations under the License.
 
 const fs = require('fs')
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
-const { createKeyValueObjectFromFlag, createKeyValueObjectFromFile, createComponentsfromSequence } = require('../../../runtime-helpers')
+const { createKeyValueArrayFromFlag, createKeyValueArrayFromFile, createComponentsfromSequence, kindForFileExtension } = require('../../../runtime-helpers')
 const { flags } = require('@oclif/command')
 
 class ActionCreate extends RuntimeBaseCommand {
+  isUpdate () { return false }
+
   async run () {
     const { args, flags } = this.parse(ActionCreate)
     const name = args.actionName
-    let action = ''
-    let paramsAction = {}
-    let annotationParams = {}
+    let exec
+    let paramsAction
+    let annotationParams
+
     try {
+      // sanity check must either be a sequence or a file but permit neither in case of an update
+      if (args.actionPath && flags.sequence) {
+        throw (new Error('Cannot specify sequence and a code artifact at the same time'))
+      } else if (!args.actionPath && !flags.sequence && !this.isUpdate()) {
+        throw (new Error('Must provide a code artifact or define a sequence'))
+      }
+
+      // can only specify main handler when also providing a file
+      if (flags.main && !args.actionPath) {
+        throw new Error('The function handler can only be specified when you provide a code artifact')
+      }
+
+      // a sequence is a system/internal function
+      if (flags.kind && flags.sequence) {
+        throw new Error('A kind may not be specified for a sequence')
+      } else if (flags.kind && !args.actionPath) {
+        throw new Error('A kind can only be specified when you provide a code artifact')
+      }
+
       if (args.actionPath) {
         if (fs.existsSync(args.actionPath)) {
+          exec = {}
+
           if (args.actionPath.endsWith('.zip')) {
-            action = fs.readFileSync(args.actionPath)
+            if (!flags.kind) {
+              throw (new Error('Invalid argument(s). creating an action from a .zip artifact requires specifying the action kind explicitly'))
+            }
+            exec.code = fs.readFileSync(args.actionPath)
           } else {
-            action = fs.readFileSync(args.actionPath, { encoding: 'utf8' })
+            exec.code = fs.readFileSync(args.actionPath, { encoding: 'utf8' })
+          }
+
+          if (flags.main) {
+            exec.main = flags.main
+          }
+
+          if (flags.kind) {
+            exec.kind = flags.kind
+          } else {
+            exec.kind = kindForFileExtension(args.actionPath)
           }
         } else {
           throw new Error('Provide a valid path for ACTION')
         }
-      }
-      if (flags.param) {
-        // each --param flag expects two values ( a key and a value ). Multiple --param flags can be passed
-        // For example : aio runtime:action:create --param name "foo" --param city "bar"
-        paramsAction = createKeyValueObjectFromFlag(flags.param)
-      } else if (flags['param-file']) {
-        paramsAction = createKeyValueObjectFromFile(flags['param-file'])
-      }
-      if (flags.annotation) {
-        // each --annotation flag expects two values ( a key and a value ). Multiple --annotation flags can be passed
-        // For example : aio runtime:action:create -a description "foo" -a sampleInput "bar"
-        annotationParams = createKeyValueObjectFromFlag(flags.annotation)
-      } else if (flags['annotation-file']) {
-        annotationParams = createKeyValueObjectFromFile(flags['annotation-file'])
-      }
-      if (flags.web) {
-        // use: --web true or --web yes to make it a web action
-        // use --web raw for raw HTTP web action
-        // TODO : Implement require-whisk-auth flag
-        switch (flags.web) {
-          case 'true':
-          case 'yes' :
-            annotationParams['web-export'] = true
-            break
-          case 'raw' :
-            annotationParams['web-export'] = true
-            annotationParams['raw-http'] = true
-        }
-      }
-
-      const ow = await this.wsk()
-      const options = {}
-      options['name'] = name
-      options['action'] = action
-      const limits = {}
-      if (flags.timeout) {
-        limits['timeout'] = flags.timeout
-      }
-      if (flags.logsize) {
-        limits['logs'] = flags.logsize
-      }
-      if (flags.memory) {
-        limits['memory'] = flags.memory
-      }
-      if (flags.sequence) {
+      } else if (flags.sequence) {
         const sequenceAction = flags.sequence.trim().split(',')
         if (sequenceAction[0].length === 0) {
           throw new Error('Provide a valid sequence component')
         } else {
-          const opts = await ow.actions.client.options
-          const ns = opts.namespace
-          options['exec'] = createComponentsfromSequence(sequenceAction, ns)
+          // use underscore (the "default" namespace) and the backend derives the namespace
+          const ns = '_'
+          exec = createComponentsfromSequence(sequenceAction, ns)
         }
       }
 
-      if (flags.main) {
-        if (!options.exec) {
-          options.exec = {}
-        }
-        options.exec.main = flags.main
+      if (flags.param) {
+        // each --param flag expects two values ( a key and a value ). Multiple --param flags can be passed
+        // For example : aio runtime:action:update --param name "foo" --param city "bar"
+        paramsAction = createKeyValueArrayFromFlag(flags.param)
+      } else if (flags['param-file']) {
+        paramsAction = createKeyValueArrayFromFile(flags['param-file'])
       }
-      options['limits'] = limits
-      options['kind'] = flags.kind
-      options['params'] = paramsAction
-      options['annotations'] = annotationParams
-      const result = await ow.actions.create(options)
+
+      if (flags.annotation) {
+        // each --annotation flag expects two values ( a key and a value ). Multiple --annotation flags can be passed
+        // For example : aio runtime:action:update -a description "foo" -a sampleInput "bar
+        annotationParams = createKeyValueArrayFromFlag(flags.annotation)
+      } else if (flags['annotation-file']) {
+        annotationParams = createKeyValueArrayFromFile(flags['annotation-file'])
+      }
+
+      if (flags.web) {
+        annotationParams = annotationParams || []
+        // use: --web true or --web yes to make it a web action and --web raw to make it raw HTTP web action
+        // TODO : Implement require-whisk-auth flag
+        switch (flags.web) {
+          case 'true':
+          case 'yes' :
+            annotationParams.push({ key: 'web-export', value: true })
+            break
+          case 'raw' :
+            annotationParams.push({ key: 'web-export', value: true })
+            annotationParams.push({ key: 'raw-http', value: true })
+            break
+          case 'false':
+          case 'no':
+            annotationParams.push({ key: 'web-export', value: false })
+        }
+      }
+
+      let limits
+      if (flags.timeout) {
+        limits = limits || {}
+        limits.timeout = flags.timeout
+      }
+      if (flags.logsize) {
+        limits = limits || {}
+        limits.logs = flags.logsize
+      }
+      if (flags.memory) {
+        limits = limits || {}
+        limits.memory = flags.memory
+      }
+
+      const options = { name }
+      if (exec) options.exec = exec
+      if (limits) options.limits = limits
+      if (paramsAction) options.parameters = paramsAction
+      if (annotationParams) options.annotations = annotationParams
+
+      const ow = await this.wsk()
+      const method = this.isUpdate() ? 'update' : 'create'
+      const result = await ow.actions[method]({ name, action: options })
       if (flags.json) {
         this.logJSON('', result)
       }
     } catch (err) {
-      this.handleError('failed to create the action', err)
+      const method = this.isUpdate() ? 'update' : 'create'
+      this.handleError(`failed to ${method} the action`, err)
     }
   }
 }
@@ -146,8 +187,7 @@ ActionCreate.flags = {
     description: 'the maximum log size LIMIT in MB for the action (default 10)' // help description for flag
   }),
   kind: flags.string({
-    description: 'the KIND of the action runtime (example: swift:default, nodejs:default)', // help description for flag
-    default: 'nodejs:10'
+    description: 'the KIND of the action runtime (example: swift:default, nodejs:default)' // help description for flag
   }),
   annotation: flags.string({
     char: 'a',

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -823,6 +823,45 @@ async function findProjectHashonServer (ow, projectName) {
   return projectHash
 }
 
+function fileExtensionForKind (kind) {
+  if (kind) {
+    const [lang] = kind.split(':')
+    switch (lang.toLowerCase()) {
+      case 'ballerina': return '.bal'
+      case 'dotnet': return '.cs'
+      case 'go': return '.go'
+      case 'java': return '.java'
+      case 'nodejs': return '.js'
+      case 'php': return '.php'
+      case 'python': return '.py'
+      case 'ruby': return '.rb'
+      case 'rust': return '.rs'
+      case 'swift': return '.swift'
+    }
+  }
+  return ''
+}
+
+function kindForFileExtension (filename) {
+  if (filename) {
+    const path = require('path')
+    const ext = path.extname(filename)
+    switch (ext.toLowerCase()) {
+      case '.bal': return 'ballerina:default'
+      case '.cs': return 'dotnet:default'
+      case '.go': return 'go:default'
+      case '.java': return 'java:default'
+      case '.js': return 'nodejs:default'
+      case '.php': return 'php:default'
+      case '.py': return 'python:default'
+      case '.rb': return 'ruby:default'
+      case '.rs': return 'rust:default'
+      case '.swift': return 'swift:default'
+    }
+  }
+  return undefined
+}
+
 module.exports = {
   createKeyValueArrayFromFile,
   createKeyValueArrayFromFlag,
@@ -850,5 +889,7 @@ module.exports = {
   findProjectHashonServer,
   getProjectHash,
   addManagedProjectAnnotations,
-  printLogs
+  printLogs,
+  fileExtensionForKind,
+  kindForFileExtension
 }

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -48,6 +48,15 @@ function printLogs (activation, strip, logger) {
 }
 
 /**
+ * @description returns key value array from the object supplied.
+ * @param object: JSON object
+ * @returns An array of key value pairs in this format : [{key : 'Your key 1' , value: 'Your value 1'}, {key : 'Your key 2' , value: 'Your value 2'} ]
+ */
+function createKeyValueArrayFromObject (object) {
+  return Object.keys(object).map(key => ({ key, value: object[key] }))
+}
+
+/**
  * @description returns key value array from the parameters supplied. Used to create --param and --annotation key value pairs
  * @param flag : flags.param or flags.annotation
  * @returns An array of key value pairs in this format : [{key : 'Your key 1' , value: 'Your value 1'}, {key : 'Your key 2' , value: 'Your value 2'} ]
@@ -863,6 +872,7 @@ function kindForFileExtension (filename) {
 }
 
 module.exports = {
+  createKeyValueArrayFromObject,
   createKeyValueArrayFromFile,
   createKeyValueArrayFromFlag,
   createKeyValueObjectFromFlag,

--- a/test/__fixtures__/action/get.json
+++ b/test/__fixtures__/action/get.json
@@ -15,6 +15,7 @@
   ],
   "exec": {
     "binary": false,
+    "kind": "nodejs:10-fat",
     "code":"this is the code"
   },
   "limits": {

--- a/test/commands/runtime/action/create.test.js
+++ b/test/commands/runtime/action/create.test.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 const { stdout } = require('stdout-stderr')
 const TheCommand = require('../../../../src/commands/runtime/action/create.js')
 const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand.js')
+const { createKeyValueArrayFromObject } = require('../../../../src/runtime-helpers.js')
 const ow = require('openwhisk')()
 const owAction = 'actions.create'
 
@@ -94,31 +95,31 @@ describe('instance methods', () => {
     })
 
     test('creates an action with action name and action path', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js']
+      command.argv = [name, '/action/actionFile.js']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ name: 'hello', action: jsFile, annotations: {}, kind: 'nodejs:10', limits: {}, params: {} })
+          expect(cmd).toHaveBeenCalledWith({ name, action: { name, exec: { code: jsFile, kind: 'nodejs:default' } } })
           expect(stdout.output).toMatch('')
         })
     })
 
     test('creates an action with action name and --sequence flag', () => {
+      const name = 'hello'
       ow.actions.client.options = { namespace: 'ns' }
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '--sequence', 'a,b,c']
+      command.argv = [name, '--sequence', 'a,b,c']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            action: '',
-            annotations: {},
-            limits: {},
-            params: {},
-            kind: 'nodejs:10',
-            exec: {
-              kind: 'sequence',
-              components: ['/ns/a', '/ns/b', '/ns/c']
+            name,
+            action: {
+              name,
+              exec: {
+                kind: 'sequence',
+                components: ['/_/a', '/_/b', '/_/c']
+              }
             }
           })
           expect(stdout.output).toMatch('')
@@ -126,82 +127,108 @@ describe('instance methods', () => {
     })
 
     test('creates an action with action name and action path --json', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '--json']
+      command.argv = [name, '/action/actionFile.js', '--json']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            action: jsFile,
-            annotations: {},
-            kind: 'nodejs:10',
-            limits: {},
-            params: {} })
-
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              }
+            }
+          })
           expect(stdout.output).toMatch('') // TODO: json version
         })
     })
 
     test('creates an action with action name and action path to zip file', () => {
+      const name = 'hello'
       const zipFile = Buffer.from('fakezipfile')
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/zipAction.zip', '--kind', 'nodejs:8']
+      command.argv = [name, '/action/zipAction.zip', '--kind', 'nodejs:8']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ name: 'hello', action: zipFile, annotations: {}, kind: 'nodejs:8', limits: {}, params: {} })
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              exec: {
+                code: zipFile,
+                kind: 'nodejs:8'
+              }
+            }
+          })
           expect(stdout.output).toMatch('')
         })
     })
 
     test('creates an action with action name, action path and --param flag', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd']
+      command.argv = [name, '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            params: { a: 'b', c: 'd' },
-            action: jsFile,
-            kind: 'nodejs:10',
-            annotations: {},
-            limits: {}
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' })
+            }
           })
           expect(stdout.output).toMatch('')
         })
     })
 
     test('creates an action with action name, action path and --param-file flag', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '--param-file', '/action/parameters.json']
+      command.argv = [name, '/action/actionFile.js', '--param-file', '/action/parameters.json']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            params: { param1: 'param1value', param2: 'param2value' },
-            action: jsFile,
-            annotations: {},
-            kind: 'nodejs:10',
-            limits: {}
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ param1: 'param1value', param2: 'param2value' })
+            }
           })
           expect(stdout.output).toMatch('')
         })
     })
 
     test('creates an action with action name, action path, --params flag and limits', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd', '--logsize', '8', '--memory', '128', '--timeout', '20000']
+      command.argv = [name, '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd', '--logsize', '8', '--memory', '128', '--timeout', '20000']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            params: { a: 'b', c: 'd' },
-            action: jsFile,
-            annotations: {},
-            kind: 'nodejs:10',
-            limits: {
-              logs: 8,
-              memory: 128,
-              timeout: 20000
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }),
+              limits: {
+                logs: 8,
+                memory: 128,
+                timeout: 20000
+              }
             }
           })
           expect(stdout.output).toMatch('')
@@ -209,163 +236,215 @@ describe('instance methods', () => {
     })
 
     test('creates an action with action name, action path, --params flag and limits with shorter flag version', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '-p', 'a', 'b', '-p', 'c', 'd', '-l', '8', '-m', '128', '-t', '20000']
+      command.argv = [name, '/action/actionFile.js', '-p', 'a', 'b', '-p', 'c', 'd', '-l', '8', '-m', '128', '-t', '20000']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            params: { a: 'b', c: 'd' },
-            action: jsFile,
-            annotations: {},
-            kind: 'nodejs:10',
-            limits: {
-              logs: 8,
-              memory: 128,
-              timeout: 20000
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }),
+              limits: {
+                logs: 8,
+                memory: 128,
+                timeout: 20000
+              }
             }
           })
           expect(stdout.output).toMatch('')
         })
     })
 
-    test('creates an action with action name, action path, --params flag ,limits and kind ', () => {
+    test('creates an action with action name, action path, --params flag, limits and kind', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd', '--logsize', '8', '--memory', '128', '--kind', 'nodejs:default']
+      command.argv = [name, '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd', '--logsize', '8', '--memory', '128', '--kind', 'nodejs:default']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            params: { a: 'b', c: 'd' },
-            action: jsFile,
-            annotations: {},
-            kind: 'nodejs:default',
-            limits: {
-              logs: 8,
-              memory: 128
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }),
+              limits: {
+                logs: 8,
+                memory: 128
+              }
             }
           })
           expect(stdout.output).toMatch('')
         })
     })
 
-    test('creates an action with action name, action path, --params flag and annotation flag ', () => {
+    test('creates an action with action name, action path, --params flag and annotation flag', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd', '--annotation', 'desc', 'Description']
+      command.argv = [name, '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd', '--annotation', 'desc', 'Description']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            params: { a: 'b', c: 'd' },
-            action: jsFile,
-            annotations: {
-              desc: 'Description'
-            },
-            kind: 'nodejs:10',
-            limits: {}
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }),
+              annotations: createKeyValueArrayFromObject({ desc: 'Description' })
+            }
           })
           expect(stdout.output).toMatch('')
         })
     })
 
-    test('creates an action with action name, action path, --params flag and annotation-file flag ', () => {
+    test('creates an action with action name, action path, --params flag and annotation-file flag', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '-p', 'a', 'b', '-p', 'c', 'd', '-A', '/action/parameters.json']
+      command.argv = [name, '/action/actionFile.js', '-p', 'a', 'b', '-p', 'c', 'd', '-A', '/action/parameters.json']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            params: { a: 'b', c: 'd' },
-            action: jsFile,
-            annotations: {
-              param1: 'param1value',
-              param2: 'param2value'
-            },
-            kind: 'nodejs:10',
-            limits: {}
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }),
+              annotations: createKeyValueArrayFromObject({ param1: 'param1value', param2: 'param2value' })
+            }
           })
           expect(stdout.output).toMatch('')
         })
     })
 
-    test('creates an action with action name, action path, --params flag web flag ', () => {
+    test('creates an action with action name, action path, --params flag web flag', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '-p', 'a', 'b', '-p', 'c', 'd', '--web', 'raw']
+      command.argv = [name, '/action/actionFile.js', '-p', 'a', 'b', '-p', 'c', 'd', '--web', 'raw']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            params: { a: 'b', c: 'd' },
-            action: jsFile,
-            annotations: {
-              'web-export': true,
-              'raw-http': true
-            },
-            kind: 'nodejs:10',
-            limits: {}
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }),
+              annotations: createKeyValueArrayFromObject({ 'web-export': true, 'raw-http': true })
+            }
           })
           expect(stdout.output).toMatch('')
         })
     })
 
-    test('creates an action with action name, action path, --params flag, annotations and web flag as true ', () => {
+    test('creates an action with action name, action path, --params flag, annotations and web flag as true', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '-p', 'a', 'b', '-p', 'c', 'd', '-a', 'desc', 'Description', '--web', 'true']
+      command.argv = [name, '/action/actionFile.js', '-p', 'a', 'b', '-p', 'c', 'd', '-a', 'desc', 'Description', '--web', 'true']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            params: { a: 'b', c: 'd' },
-            action: jsFile,
-            annotations: {
-              'web-export': true,
-              desc: 'Description'
-            },
-            kind: 'nodejs:10',
-            limits: {}
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }),
+              annotations: createKeyValueArrayFromObject({ desc: 'Description', 'web-export': true })
+            }
           })
           expect(stdout.output).toMatch('')
         })
     })
 
     test('creates an action with --main flag', () => {
+      const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '--main', 'maynard']
+      command.argv = [name, '/action/actionFile.js', '--main', 'maynard']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            exec: { main: 'maynard' },
-            params: {},
-            action: jsFile,
-            annotations: {},
-            kind: 'nodejs:10',
-            limits: {}
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                main: 'maynard',
+                kind: 'nodejs:default'
+              }
+            }
           })
           expect(stdout.output).toMatch('')
         })
     })
 
-    test('creates an action with --main flag and --sequence', () => {
-      const cmd = ow.mockResolved(owAction, '')
-      command.argv = ['hello', '/action/actionFile.js', '--main', 'maynard', '--sequence', 'a,b,c']
-      return command.run()
-        .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
-            name: 'hello',
-            exec: {
-              main: 'maynard',
-              kind: 'sequence',
-              components: ['/ns/a', '/ns/b', '/ns/c']
-            },
-            params: {},
-            action: jsFile,
-            annotations: {},
-            kind: 'nodejs:10',
-            limits: {}
+    test('creates an action with code and --sequence', () => {
+      return new Promise((resolve, reject) => {
+        ow.mockRejected(owAction, '')
+        command.argv = ['hello', '/action/actionFile.js', '--sequence', 'a,b,c']
+        return command.run()
+          .then(() => reject(new Error('does not throw error')))
+          .catch(() => {
+            expect(handleError).toHaveBeenLastCalledWith('failed to create the action', new Error('Cannot specify sequence and a code artifact at the same time'))
+            resolve()
           })
-          expect(stdout.output).toMatch('')
-        })
+      })
+    })
+
+    test('tests for incorrect action with --main flag and --sequence', () => {
+      return new Promise((resolve, reject) => {
+        ow.mockRejected(owAction, '')
+        command.argv = ['hello', '--main', 'maynard', '--sequence', 'a,b,c']
+        return command.run()
+          .then(() => reject(new Error('does not throw error')))
+          .catch(() => {
+            expect(handleError).toHaveBeenLastCalledWith('failed to create the action', new Error('The function handler can only be specified when you provide a code artifact'))
+            resolve()
+          })
+      })
+    })
+
+    test('tests for incorrect action create missing code and sequence', () => {
+      return new Promise((resolve, reject) => {
+        ow.mockRejected(owAction, '')
+        command.argv = ['hello']
+        return command.run()
+          .then(() => reject(new Error('does not throw error')))
+          .catch(() => {
+            expect(handleError).toHaveBeenLastCalledWith('failed to create the action', new Error('Must provide a code artifact or define a sequence'))
+            resolve()
+          })
+      })
+    })
+
+    test('tests for incorrect action with --kind flag and --sequence', () => {
+      return new Promise((resolve, reject) => {
+        ow.mockRejected(owAction, '')
+        command.argv = ['hello', '--kind', 'nodejs:10', '--sequence', 'a,b,c']
+        return command.run()
+          .then(() => reject(new Error('does not throw error')))
+          .catch(() => {
+            expect(handleError).toHaveBeenLastCalledWith('failed to create the action', new Error('A kind may not be specified for a sequence'))
+            resolve()
+          })
+      })
     })
 
     test('tests for incorrect --param flags', () => {

--- a/test/runtime-helpers.test.js
+++ b/test/runtime-helpers.test.js
@@ -99,3 +99,48 @@ describe('parsePathPattern', () => {
     expect(name).toEqual('name1')
   })
 })
+
+describe('fileExtensionForKind', () => {
+  test('map action kind to file extension', () => {
+    expect(TheHelper.fileExtensionForKind('ballerina:abc')).toEqual('.bal')
+    expect(TheHelper.fileExtensionForKind('dotnet:abc')).toEqual('.cs')
+    expect(TheHelper.fileExtensionForKind('go:abc')).toEqual('.go')
+    expect(TheHelper.fileExtensionForKind('java:abc')).toEqual('.java')
+    expect(TheHelper.fileExtensionForKind('nodejs:abc')).toEqual('.js')
+    expect(TheHelper.fileExtensionForKind('php:abc')).toEqual('.php')
+    expect(TheHelper.fileExtensionForKind('python:abc')).toEqual('.py')
+    expect(TheHelper.fileExtensionForKind('ruby:abc')).toEqual('.rb')
+    expect(TheHelper.fileExtensionForKind('rust:abc')).toEqual('.rs')
+    expect(TheHelper.fileExtensionForKind('swift:abc')).toEqual('.swift')
+
+    // all kinds are colon separated but test defensively anyway
+    expect(TheHelper.fileExtensionForKind('swift')).toEqual('.swift')
+
+    // unknown kinds return ''
+    expect(TheHelper.fileExtensionForKind('???:???')).toEqual('')
+    expect(TheHelper.fileExtensionForKind('???')).toEqual('')
+    expect(TheHelper.fileExtensionForKind('')).toEqual('')
+    expect(TheHelper.fileExtensionForKind(undefined)).toEqual('')
+  })
+})
+
+describe('kindForFileExtension', () => {
+  test('map action kind to file extension', () => {
+    expect(TheHelper.kindForFileExtension('f.bal')).toEqual('ballerina:default')
+    expect(TheHelper.kindForFileExtension('f.cs')).toEqual('dotnet:default')
+    expect(TheHelper.kindForFileExtension('f.go')).toEqual('go:default')
+    expect(TheHelper.kindForFileExtension('f.java')).toEqual('java:default')
+    expect(TheHelper.kindForFileExtension('f.js')).toEqual('nodejs:default')
+    expect(TheHelper.kindForFileExtension('f.php')).toEqual('php:default')
+    expect(TheHelper.kindForFileExtension('f.py')).toEqual('python:default')
+    expect(TheHelper.kindForFileExtension('f.rb')).toEqual('ruby:default')
+    expect(TheHelper.kindForFileExtension('f.rs')).toEqual('rust:default')
+    expect(TheHelper.kindForFileExtension('f.swift')).toEqual('swift:default')
+
+    expect(TheHelper.kindForFileExtension(undefined)).toEqual(undefined)
+    expect(TheHelper.kindForFileExtension('')).toEqual(undefined)
+    expect(TheHelper.kindForFileExtension('.')).toEqual(undefined)
+    expect(TheHelper.kindForFileExtension('.js')).toEqual(undefined)
+    expect(TheHelper.kindForFileExtension('???')).toEqual(undefined)
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows action update without a code artifact.
    
To address a number of subtleties in the implementation between action create/get and the gap relative to the Apache OpenWhisk CLI (wsk), this patch consolidates the implementation of action create and update so that they are interchangeable.
    
Summary of changes:
    1. action kind determined from file extension
    2. disallow action artifact and --sequence
    3. dissallow --main on sequence
    4. allow update to omit all parameters
    5. allow an update to parameters and annotations without replacing code

I have added a number of new tests to cover the changes herein as well.
This PR includes a small patch needed from #69. 

<!--- Describe your changes in detail -->

## Related Issue
Closes #70.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
