### PR TITLE
Use fully qualified names for sequence components.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "js-yaml": "^3.13.1",
     "node-fetch": "^2.3.0",
     "openwhisk": "^3.20.0",
+    "openwhisk-fqn": "^0.0.2",
     "properties-reader": "0.3.0",
     "sha1": "^1.1.1"
   },

--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -75,9 +75,7 @@ class ActionCreate extends RuntimeBaseCommand {
         if (sequenceAction[0].length === 0) {
           throw new Error('Provide a valid sequence component')
         } else {
-          // use underscore (the "default" namespace) and the backend derives the namespace
-          const ns = '_'
-          exec = createComponentsfromSequence(sequenceAction, ns)
+          exec = createComponentsfromSequence(sequenceAction)
         }
       }
 

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -136,12 +136,13 @@ function createKeyValueObjectFromFile (file) {
   return JSON.parse(jsonData)
 }
 
-function createComponentsfromSequence (sequenceAction, ns) {
+function createComponentsfromSequence (sequenceAction) {
+  const fqn = require('openwhisk-fqn')
   const objSequence = {}
   objSequence['kind'] = 'sequence'
   // The components array requires fully qualified names [/namespace/package_name/action_name] of all the actions passed as sequence
-  sequenceAction = sequenceAction.map(sequence => {
-    return `/${ns}/${sequence}`
+  sequenceAction = sequenceAction.map(component => {
+    return fqn(component)
   })
   objSequence['components'] = sequenceAction
   return objSequence

--- a/test/commands/runtime/action/create.test.js
+++ b/test/commands/runtime/action/create.test.js
@@ -109,7 +109,7 @@ describe('instance methods', () => {
       const name = 'hello'
       ow.actions.client.options = { namespace: 'ns' }
       const cmd = ow.mockResolved(owAction, '')
-      command.argv = [name, '--sequence', 'a,b,c']
+      command.argv = [name, '--sequence', 'a,p/b,ns/p/c,/ns2/p/d,/ns3/e']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
@@ -118,7 +118,7 @@ describe('instance methods', () => {
               name,
               exec: {
                 kind: 'sequence',
-                components: ['/_/a', '/_/b', '/_/c']
+                components: ['/_/a', '/_/p/b', '/ns/p/c', '/ns2/p/d', '/ns3/e']
               }
             }
           })

--- a/test/commands/runtime/action/update.test.js
+++ b/test/commands/runtime/action/update.test.js
@@ -181,7 +181,7 @@ describe('instance methods', () => {
       const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')
       ow.actions.client.options = { namespace: 'ns' }
-      command.argv = [name, '--sequence', 'a,b,c']
+      command.argv = [name, '--sequence', 'a,p/b,ns/p/c,/ns2/p/d,/ns3/e']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({
@@ -190,7 +190,7 @@ describe('instance methods', () => {
               name,
               exec: {
                 kind: 'sequence',
-                components: ['/_/a', '/_/b', '/_/c']
+                components: ['/_/a', '/_/p/b', '/ns/p/c', '/ns2/p/d', '/ns3/e']
               }
             }
           })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use fully qualified names for sequence components during construction of action sequence.
If you accept #72 then a rebased implementation of this patch is available at https://github.com/adobe/aio-cli-plugin-runtime/commit/88ef0a561ea2ff047e2beabf582b34c3c5deca39 and I can PR that instead.

## Related Issue
Closes #73.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
