### PR TITLE
Base64 encode zip/binary files for action create/update.

### DIFF
--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -49,11 +49,11 @@ class ActionCreate extends RuntimeBaseCommand {
         if (fs.existsSync(args.actionPath)) {
           exec = {}
 
-          if (args.actionPath.endsWith('.zip')) {
+          if (args.actionPath.endsWith('.zip') || flags.binary) {
             if (!flags.kind) {
               throw (new Error('Invalid argument(s). creating an action from a .zip artifact requires specifying the action kind explicitly'))
             }
-            exec.code = fs.readFileSync(args.actionPath)
+            exec.code = fs.readFileSync(args.actionPath).toString('base64')
           } else {
             exec.code = fs.readFileSync(args.actionPath, { encoding: 'utf8' })
           }
@@ -201,6 +201,9 @@ ActionCreate.flags = {
   }),
   main: flags.string({
     description: 'the name of the action entry point (function or fully-qualified method name when applicable)'
+  }),
+  binary: flags.boolean({
+    description: 'treat code artifact as binary'
   }),
   json: flags.boolean({
     description: 'output raw json'

--- a/test/commands/runtime/action/create.test.js
+++ b/test/commands/runtime/action/create.test.js
@@ -77,7 +77,8 @@ describe('instance methods', () => {
     const json = {
       'action/parameters.json': fixtureFile('trigger/parameters.json'),
       'action/actionFile.js': fixtureFile('action/actionFile.js'),
-      'action/zipAction.zip': 'fakezipfile'
+      'action/zipAction.zip': 'fakezipfile',
+      'action/zipAction.bin': 'fakezipfile'
     }
     fakeFileSystem.addJson(json)
   })
@@ -148,9 +149,30 @@ describe('instance methods', () => {
 
     test('creates an action with action name and action path to zip file', () => {
       const name = 'hello'
-      const zipFile = Buffer.from('fakezipfile')
+      const zipFile = Buffer.from('fakezipfile').toString('base64')
       const cmd = ow.mockResolved(owAction, '')
       command.argv = [name, '/action/zipAction.zip', '--kind', 'nodejs:8']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              exec: {
+                code: zipFile,
+                kind: 'nodejs:8'
+              }
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('creates an action with action name and action path to binary file', () => {
+      const name = 'hello'
+      const zipFile = Buffer.from('fakezipfile').toString('base64')
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = [name, '/action/zipAction.bin', '--kind', 'nodejs:8', '--binary']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalledWith({

--- a/test/commands/runtime/action/update.test.js
+++ b/test/commands/runtime/action/update.test.js
@@ -129,7 +129,7 @@ describe('instance methods', () => {
 
     test('updates an action with action name and action path to zip file', () => {
       const name = 'hello'
-      const zipFile = Buffer.from('fakezipfile')
+      const zipFile = Buffer.from('fakezipfile').toString('base64')
       const cmd = ow.mockResolved(owAction, '')
       command.argv = [name, '/action/zipAction.zip', '--kind', 'nodejs:10']
       return command.run()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Base64 encode binary/zip files so they are API compatible. 
This PR also adds a `--binary` flag for files that are not just `.zip` but should be treated the same way.

## Related Issue

Closes #85.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested against AIO as well as unit tests.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
