### PR TITLE
fix 400 when undef env vars in manifest

### DIFF
--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -190,7 +190,7 @@ function processInputs (input, params) {
         } else if (typeof input[key] === 'string' && input[key].startsWith('$')) {
           let val = input[key]
           val = val.substr(1)
-          input[key] = process.env[val]
+          input[key] = process.env[val] || ''
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
currently when deploying an action with an input that points to an undef env variable e.g.:
```
packages:
  __APP_PACKAGE__:
    license: Apache-2.0
    actions:
      target:
        function: actions/target/index.js
        web: 'yes'
        runtime: 'nodejs:10'
        inputs:
          tenant: $TARGET_TENANT --> is not defined
```

 the deployment fails with the following error: 
```
ℹ Info: Deploying action [playground-0.0.1/target]...
✖ Deploy actions
OpenWhiskError: PUT https://adobeioruntime.net/api/v1/namespaces/<ns>/actions/<package>/target?overwrite=true Returned HTTP 400 (Bad Request) --> "The request content was malformed:
parameters malformed!"
    at Client.handleErrors (~/.nvm/versions/node/v10.15.3/lib/node_modules/@adobe/aio-cli/node_modules/openwhisk/lib/client.js:216:11)
    at params.then.catch.err (~/.nvm/versions/node/v10.15.3/lib/node_modules/@adobe/aio-cli/node_modules/openwhisk/lib/client.js:147:58)
```
<!--- Describe your changes in detail -->

This PR fixes this problem by replacing undef ENV with `''`

## Motivation and Context
The error is hard to debug for the user

## Alternative solution
If preferred an alternative solution is to throw a better error saying that the env var is not defined

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
