### PR TITLE
ACNA-625 - Check row.annotations before iterating

### DIFF
--- a/src/commands/runtime/activation/list.js
+++ b/src/commands/runtime/activation/list.js
@@ -62,8 +62,8 @@ class ActivationList extends RuntimeBaseCommand {
           },
           Kind: {
             get: (row) => {
-              const { annotations } = row;
-              if (!annotations || !annotations.length) return;
+              const { annotations } = row
+              if (!annotations || !annotations.length) return
               return annotations.find((elem) => {
                 return (elem.key === 'kind')
               }).value
@@ -71,8 +71,8 @@ class ActivationList extends RuntimeBaseCommand {
           },
           Start: {
             get: (row) => {
-              const { annotations } = row;
-              if (!annotations || !annotations.length) return;
+              const { annotations } = row
+              if (!annotations || !annotations.length) return
               const elem = annotations.find((elem) => {
                 return (elem.key === 'initTime')
               })
@@ -90,8 +90,8 @@ class ActivationList extends RuntimeBaseCommand {
           },
           Entity: {
             get: (row) => {
-              const { annotations } = row;
-              if (!annotations || !annotations.length) return;
+              const { annotations } = row
+              if (!annotations || !annotations.length) return
               const path = annotations.find((elem) => {
                 return (elem.key === 'path')
               }).value

--- a/src/commands/runtime/activation/list.js
+++ b/src/commands/runtime/activation/list.js
@@ -62,14 +62,18 @@ class ActivationList extends RuntimeBaseCommand {
           },
           Kind: {
             get: (row) => {
-              return row.annotations.find((elem) => {
+              const { annotations } = row;
+              if (!annotations || !annotations.length) return;
+              return annotations.find((elem) => {
                 return (elem.key === 'kind')
               }).value
             }
           },
           Start: {
             get: (row) => {
-              const elem = row.annotations.find((elem) => {
+              const { annotations } = row;
+              if (!annotations || !annotations.length) return;
+              const elem = annotations.find((elem) => {
                 return (elem.key === 'initTime')
               })
               return elem ? 'cold' : 'warm'
@@ -86,7 +90,9 @@ class ActivationList extends RuntimeBaseCommand {
           },
           Entity: {
             get: (row) => {
-              const path = row.annotations.find((elem) => {
+              const { annotations } = row;
+              if (!annotations || !annotations.length) return;
+              const path = annotations.find((elem) => {
                 return (elem.key === 'path')
               }).value
               return `${path}:${row.version}`

--- a/test/commands/runtime/activation/list.test.js
+++ b/test/commands/runtime/activation/list.test.js
@@ -190,5 +190,27 @@ describe('instance methods', () => {
           })
       })
     })
+
+    test('ignore activation without annotations', () => {
+      const data = [
+        {
+          activationId: '12345',
+          annotations: [
+          ],
+          duration: 23,
+          name: 'foo',
+          namespace: '8888_9999',
+          start: 1558507178861,
+          statusCode: 0,
+          version: '0.0.1'
+        }]
+      const cmd = ow.mockResolved(owAction, data)
+      command.argv = ['12345']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({ name: '12345' })
+          expect(stdout.output).toMatch('')
+        })
+    })
   })
 })


### PR DESCRIPTION
## Description

I added empty checks to `row.annotations` before iterating over it.
The fix covers only the activations, not the actions.

## Related Issue

## Motivation and Context

## How Has This Been Tested?

I hit this bug on my environment, and after monkey patching the npm module the issue is fixed.
Therefore I wanted to contribute the fix as PR.

## Screenshots (if appropriate):

## Types of changes

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
