### PR TITLE
Fix action get --url for fully qualified action name.

### DIFF
--- a/src/commands/runtime/action/get.js
+++ b/src/commands/runtime/action/get.js
@@ -31,25 +31,23 @@ class ActionGet extends RuntimeBaseCommand {
           Properties.APIVersion
           qualifiedName.GetPackageName()
         */
-        let web = 'namespaces'
-        let actionValue = '/actions'
-        const webFlag = result.annotations.find(elem => elem.key === 'web-export')
-        let actionPartOfPackage = false
-        // check if action belongs to a package
-        if (name.split('/').length > 1) {
-          actionPartOfPackage = true
-        }
-        if (webFlag !== undefined && webFlag.value === true) {
-          web = 'web'
-          if (actionPartOfPackage) {
-            actionValue = ''
-          } else {
-            actionValue = '/default'
-          }
-        }
-        const [namespace] = result.namespace.split('/')
         const opts = ow.actions.client.options
-        this.log(`${opts.api}${web}/${namespace}${actionValue}/${name}`)
+        const webFlag = result.annotations.find(elem => elem.key === 'web-export')
+        const webAction = webFlag !== undefined && webFlag.value === true
+
+        let [namespace, packageName] = result.namespace.split('/')
+        const actionPartOfPackage = !!packageName
+
+        if (webAction) {
+          const web = 'web'
+          packageName = actionPartOfPackage ? packageName : 'default'
+          this.log(`${opts.api}${web}/${namespace}/${packageName}/${result.name}`)
+        } else {
+          const nsPrefix = 'namespaces'
+          const actionPrefix = 'actions'
+          packageName = actionPartOfPackage ? packageName + '/' : ''
+          this.log(`${opts.api}${nsPrefix}/${namespace}/${actionPrefix}/${packageName}${result.name}`)
+        }
       } else {
         const bSaveFile = flags['save-as'] && flags['save-as'].length > 0
 

--- a/test/__fixtures__/action/get-package.json
+++ b/test/__fixtures__/action/get-package.json
@@ -1,0 +1,32 @@
+{
+  "annotations": [
+    {
+      "key": "web-export",
+      "value": true
+    },
+    {
+      "key": "raw-http",
+      "value": true
+    },
+    {
+      "key": "exec",
+      "value": "nodejs:10-fat"
+    }
+  ],
+  "exec": {
+    "binary": false,
+    "kind": "nodejs:10-fat",
+    "code":"this is the code"
+  },
+  "limits": {
+    "concurrency": 1,
+    "logs": 10,
+    "memory": 256,
+    "timeout": 60000
+  },
+  "name": "hello",
+  "namespace": "53444_41603/test",
+  "publish": false,
+  "updated": 1549408742750,
+  "version": "0.0.2"
+}

--- a/test/__fixtures__/action/getWebFalse-package.json
+++ b/test/__fixtures__/action/getWebFalse-package.json
@@ -1,0 +1,31 @@
+{
+  "annotations": [
+    {
+      "key": "web-export",
+      "value": false
+    },
+    {
+      "key": "raw-http",
+      "value": false
+    },
+    {
+      "key": "exec",
+      "value": "nodejs:10-fat"
+    }
+  ],
+  "exec": {
+    "binary": false,
+    "code":"this is the code"
+  },
+  "limits": {
+    "concurrency": 1,
+    "logs": 10,
+    "memory": 256,
+    "timeout": 60000
+  },
+  "name": "hello",
+  "namespace": "53444_41603/test",
+  "publish": false,
+  "updated": 1549408742750,
+  "version": "0.0.2"
+}

--- a/test/commands/runtime/action/get.test.js
+++ b/test/commands/runtime/action/get.test.js
@@ -76,10 +76,58 @@ describe('instance methods', () => {
     })
 
     test('retrieve an action --url with web flags from package', () => {
-      const cmd = ow.mockResolvedFixture(owAction, 'action/get.json')
+      const cmd = ow.mockResolvedFixture(owAction, 'action/get-package.json')
       ow.mockResolved('actions.client.options', '')
       ow.actions.client.options = { api: 'api/' }
       command.argv = ['test/hello', '--url']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalled()
+          expect(stdout.output).toMatch('api/web/53444_41603/test/hello')
+        })
+    })
+
+    test('retrieve an action --url with web flags from fully qualified name with implicit namespace and no package', () => {
+      const cmd = ow.mockResolvedFixture(owAction, 'action/get.json')
+      ow.mockResolved('actions.client.options', '')
+      ow.actions.client.options = { api: 'api/' }
+      command.argv = ['/_/hello', '--url']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalled()
+          expect(stdout.output).toMatch('api/web/53444_41603/default/hello')
+        })
+    })
+
+    test('retrieve an action --url with web flags from fully qualified name using explicit namespace and no package', () => {
+      const cmd = ow.mockResolvedFixture(owAction, 'action/get.json')
+      ow.mockResolved('actions.client.options', '')
+      ow.actions.client.options = { api: 'api/' }
+      command.argv = ['/_/hello', '--url']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalled()
+          expect(stdout.output).toMatch('api/web/53444_41603/default/hello')
+        })
+    })
+
+    test('retrieve an action --url with web flags from fully qualified name with implicit namespace', () => {
+      const cmd = ow.mockResolvedFixture(owAction, 'action/get-package.json')
+      ow.mockResolved('actions.client.options', '')
+      ow.actions.client.options = { api: 'api/' }
+      command.argv = ['/_/test/hello', '--url']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalled()
+          expect(stdout.output).toMatch('api/web/53444_41603/test/hello')
+        })
+    })
+
+    test('retrieve an action --url with web flags from fully qualified name using explicit namespace', () => {
+      const cmd = ow.mockResolvedFixture(owAction, 'action/get-package.json')
+      ow.mockResolved('actions.client.options', '')
+      ow.actions.client.options = { api: 'api/' }
+      command.argv = ['/_/test/hello', '--url']
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalled()
@@ -96,6 +144,18 @@ describe('instance methods', () => {
         .then(() => {
           expect(cmd).toHaveBeenCalled()
           expect(stdout.output).toMatch('api/namespaces/53444_41603/actions/hello')
+        })
+    })
+
+    test('retrieve an action --url in package without web flags', () => {
+      const cmd = ow.mockResolvedFixture(owAction, 'action/getWebFalse-package.json')
+      ow.mockResolved('actions.client.options', '')
+      ow.actions.client.options = { api: 'api/' }
+      command.argv = ['hello', '--url']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalled()
+          expect(stdout.output).toMatch('api/namespaces/53444_41603/actions/test/hello')
         })
     })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes action get --url issues when the action name is fully specified. The implementation now uses the result of action get as the canonical source from which to reconstruct the URL.

## Related Issue

Closes https://github.com/adobe/aio-cli-plugin-runtime/issues/94.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
