### PR TITLE
syncProject flag to not delete entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/aio-cli-plugin-runtime",
   "description": "Adobe I/O Runtime commands for the Adobe I/O CLI",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Adobe Inc.",
   "bugs": "https://github.com/adobe/aio-cli-plugin-runtime/issues",
   "dependencies": {

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -669,7 +669,7 @@ async function undeployPackage (entities, ow, logger) {
   logger('Success: Undeployment completed successfully.')
 }
 
-async function syncProject (projectName, manifestPath, manifestContent, entities, ow, logger) {
+async function syncProject (projectName, manifestPath, manifestContent, entities, ow, logger, deleteEntities = true) {
   // find project hash from server based on entities in the manifest file
   const hashProjectSynced = await findProjectHashonServer(ow, projectName)
 
@@ -677,7 +677,7 @@ async function syncProject (projectName, manifestPath, manifestContent, entities
   const projectHash = getProjectHash(manifestContent, manifestPath)
   await addManagedProjectAnnotations(entities, manifestPath, projectName, projectHash)
   await deployPackage(entities, ow, logger)
-  if (projectHash !== hashProjectSynced) {
+  if (deleteEntities && (projectHash !== hashProjectSynced)) {
     // delete old files with same project name that do not exist in the manifest file anymore
     const junkEntities = await getProjectEntities(hashProjectSynced, true, ow)
     await undeployPackage(junkEntities, ow, () => {})


### PR DESCRIPTION
Support for deploying single action. In such cases we don’t need to delete junk entities.

<!--- Provide a general summary of your changes in the Title above -->

## Description

When deploying single action we don't want to delete other deployed entities.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

manual tests running cli command

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
