### PR TITLE
Support action create/update -e for adding environment variables to actions.

### DIFF
--- a/test/commands/runtime/action/create.test.js
+++ b/test/commands/runtime/action/create.test.js
@@ -308,6 +308,105 @@ describe('instance methods', () => {
         })
     })
 
+    test('creates an action with action name, action path and --env flag', () => {
+      const name = 'hello'
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = [name, '/action/actionFile.js', '--env', 'a', 'b', '--env', 'c', 'd']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }).map(_ => ({ ..._, init: true }))
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('creates an action with action name, action path and --e flag', () => {
+      const name = 'hello'
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = [name, '/action/actionFile.js', '--env', 'a', 'b', '-e', 'c', 'd']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }).map(_ => ({ ..._, init: true }))
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('creates an action with action name, action path and --env and --param flag', () => {
+      const name = 'hello'
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = [name, '/action/actionFile.js', '--env', 'a', 'b', '--param', 'c', 'd']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              // order matters in array for the check, env params come last
+              parameters: createKeyValueArrayFromObject({ c: 'd', a: 'b' }).map(_ => { return _.key === 'a' ? { ..._, init: true } : _ })
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('creates an action with action name, action path and overlapping --env and --param keys', () => {
+      return new Promise((resolve, reject) => {
+        ow.mockRejected(owAction, '')
+        const name = 'hello'
+        command.argv = [name, '/action/actionFile.js', '--env', 'a', 'b', '--param', 'a', 'd']
+        return command.run()
+          .then(() => reject(new Error('does not throw error')))
+          .catch(() => {
+            expect(handleError).toHaveBeenLastCalledWith('failed to create the action', new Error('Invalid argument(s). Environment variables and function parameters may not overlap'))
+            resolve()
+          })
+      })
+    })
+
+    test('creates an action with action name, action path and --env-file flag', () => {
+      const name = 'hello'
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = [name, '/action/actionFile.js', '--env-file', '/action/parameters.json']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ param1: 'param1value', param2: 'param2value' }).map(_ => ({ ..._, init: true }))
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
     test('creates an action with action name, action path, --params flag and annotation flag', () => {
       const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')

--- a/test/commands/runtime/action/update.test.js
+++ b/test/commands/runtime/action/update.test.js
@@ -352,6 +352,93 @@ describe('instance methods', () => {
         })
     })
 
+    test('updates an action with action name --env flag', () => {
+      const name = 'hello'
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = [name, '--env', 'a', 'b', '--env', 'c', 'd']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }).map(_ => ({ ..._, init: true }))
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('updates an action with action name and --e flag', () => {
+      const name = 'hello'
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = [name, '--env', 'a', 'b', '-e', 'c', 'd']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              parameters: createKeyValueArrayFromObject({ a: 'b', c: 'd' }).map(_ => ({ ..._, init: true }))
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('updates an action with action name --env and --param flag', () => {
+      const name = 'hello'
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = [name, '--env', 'a', 'b', '--param', 'c', 'd']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              // order matters in array for the check, env params come last
+              parameters: createKeyValueArrayFromObject({ c: 'd', a: 'b' }).map(_ => { return _.key === 'a' ? { ..._, init: true } : _ })
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('update an action with action name and overlapping --env and --param keys', () => {
+      return new Promise((resolve, reject) => {
+        ow.mockRejected(owAction, '')
+        const name = 'hello'
+        command.argv = [name, '--env', 'a', 'b', '--param', 'a', 'd']
+        return command.run()
+          .then(() => reject(new Error('does not throw error')))
+          .catch(() => {
+            expect(handleError).toHaveBeenLastCalledWith('failed to update the action', new Error('Invalid argument(s). Environment variables and function parameters may not overlap'))
+            resolve()
+          })
+      })
+    })
+
+    test('update an action with action name, action path and --env-file flag', () => {
+      const name = 'hello'
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = [name, '/action/actionFile.js', '--env-file', '/action/parameters.json']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:default'
+              },
+              parameters: createKeyValueArrayFromObject({ param1: 'param1value', param2: 'param2value' }).map(_ => ({ ..._, init: true }))
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
     test('updates an action with action name and log limits', () => {
       const name = 'hello'
       const cmd = ow.mockResolved(owAction, '')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enhancement covered by https://github.com/adobe/aio-cli-plugin-runtime/issues/83.
Support -e for adding environment variables on action create/update, binding specified parameters to environment/init variables. The `-e` flag mirrors `-p`.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
