### PR TITLE
Fixes action invoke defects

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cli-ux": "^5.2.0",
     "js-yaml": "^3.13.1",
     "node-fetch": "^2.3.0",
-    "openwhisk": "^3.20.0",
+    "openwhisk": "^3.21.1",
     "openwhisk-fqn": "^0.0.2",
     "properties-reader": "0.3.0",
     "sha1": "^1.1.1"


### PR DESCRIPTION

## Description

This closes two issues, #91 and #101.

1. if the activation request is synchronous but demoted by the backend, the result is an activation id only
2. if the result of the activation is an error response (function returns an error), emit the result and not an error

## Related Issue

- #91 
- #101

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
