### PR TITLE
Tweak missing property messages to improve clarity

### DIFF
--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -349,7 +349,7 @@ function checkWebFlags (flag) {
 function createActionObject (thisAction, objAction) {
   if (thisAction['function'].endsWith('.zip')) {
     if (!thisAction['runtime']) {
-      throw (new Error(`Invalid or missing runtime in the manifest for this action: ${objAction.name}`))
+      throw (new Error(`Invalid or missing property "runtime" in the manifest for this action: ${objAction.name}`))
     }
     objAction.action = fs.readFileSync(thisAction['function'])
   } else {
@@ -407,7 +407,7 @@ function processPackage (packages, deploymentPackages, deploymentTriggers, param
               }
             }
           } catch (ex) {
-            throw (new Error(`Invalid or missing location in the manifest for this action: ${depName}`))
+            throw (new Error(`Invalid or missing property "location" in the manifest for this action: ${depName}`))
           }
           // Parse inputs
           let deploymentInputs = {}

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -459,7 +459,7 @@ describe('instance methods', () => {
         return command.run()
           .then(() => reject(new Error('does not throw error')))
           .catch(() => {
-            expect(handleError).toHaveBeenLastCalledWith('Failed to deploy', new Error('Invalid or missing location in the manifest for this action: mypackage'))
+            expect(handleError).toHaveBeenLastCalledWith('Failed to deploy', new Error('Invalid or missing property "location" in the manifest for this action: mypackage'))
             resolve()
           })
       })
@@ -746,7 +746,7 @@ describe('instance methods', () => {
         return command.run()
           .then(() => reject(new Error('does not throw error')))
           .catch(() => {
-            expect(handleError).toHaveBeenLastCalledWith('Failed to deploy', new Error('Invalid or missing runtime in the manifest for this action: demo_package/sampleAction'))
+            expect(handleError).toHaveBeenLastCalledWith('Failed to deploy', new Error('Invalid or missing property "runtime" in the manifest for this action: demo_package/sampleAction'))
             resolve()
           })
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hey! Still learning I/O ins and outs, and went to copy some config in `manifest.yml` to create a second function for my application.

Unfortunately I missed some fields, specifically the `runtime` field. The following error message was flushed when running `aio app deploy`:

```sh
Error: Invalid or missing runtime in the manifest for this action: store-locator-extension-0.0.1/graphql
```

When I read this message, I was thinking of `runtime` more as an Adobe concept, and it didn't immediately occur to me that `runtime` was a _property_ name.

Tweaked two error messages to (hopefully) add some clarity.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Easier onboarding for new folks
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Functionality is already covered by unit tests, just updated the error string we're asserting on
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
