### PR TITLE
Fix uncaught async exception warnings in unit tests. Closes #95

### DIFF
--- a/src/commands/runtime/activation/logs.js
+++ b/src/commands/runtime/activation/logs.js
@@ -32,14 +32,14 @@ class ActivationLogs extends RuntimeBaseCommand {
     }
 
     const logger = this.log
-    activations.forEach((ax) => {
-      ow.activations.logs(ax.activationId).then((result) => {
+    await Promise.all(activations.map((ax) => {
+      return ow.activations.logs(ax.activationId).then((result) => {
         logger(chalk.dim('=== ') + chalk.bold('activation logs %s %s:%s'), ax.activationId, ax.name || '', ax.version || '')
         printLogs(result, flags.strip, logger)
       }, (err) => {
         this.handleError('failed to retrieve logs for activation', err)
       })
-    })
+    }))
   }
 }
 

--- a/test/commands/runtime/activation/logs.test.js
+++ b/test/commands/runtime/activation/logs.test.js
@@ -97,7 +97,7 @@ describe('instance methods', () => {
       const cmd = ow.mockRejected(owAction, new Error('Async error'))
       command.argv = ['-l', '-c', '2']
       return command.run()
-        .then(() => {
+        .catch(() => {
           expect(cmd).toHaveBeenCalledWith('12345')
           expect(handleError).toHaveBeenCalledWith('failed to retrieve logs for activation', expect.any(Error))
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I noticed #95 when working on #107. I made the minimal changes necessary to fix things up.

<!--- Describe your changes in detail -->

## Related Issue
#95

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
No promises were being returned in the body of `ActivationLogs.prototype.run`, and  there was no `await` suspending execution of the function, so the `forEach` would finish immediately and `run` would return execution _before_ the calls to `ow.activations.logs` resolved.

Now we're collecting the promises and `await`ing them. If any throw, the `await` will now cause the _first_ error to propagate up the promise chain.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
