### PR TITLE
Only emit rule delete if json flag is given.

### DIFF
--- a/src/commands/runtime/rule/delete.js
+++ b/src/commands/runtime/rule/delete.js
@@ -10,15 +10,18 @@ governing permissions and limitations under the License.
 */
 
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
+const { flags } = require('@oclif/command')
 
 class RuleDelete extends RuntimeBaseCommand {
   async run () {
-    const { args } = this.parse(RuleDelete)
+    const { flags, args } = this.parse(RuleDelete)
     try {
       const ow = await this.wsk()
       const RuleDeleteObject = { ...args }
       const deleteRule = await ow.rules.delete(RuleDeleteObject)
-      this.log(`Rules Deleted! ${JSON.stringify(deleteRule, null, 2)}`)
+      if (flags.json) {
+        this.logJSON('', deleteRule)
+      }
     } catch (err) {
       this.handleError('failed to delete rules', err)
     }
@@ -36,7 +39,10 @@ RuleDelete.args = [
 ]
 
 RuleDelete.flags = {
-  ...RuntimeBaseCommand.flags
+  ...RuntimeBaseCommand.flags,
+  json: flags.boolean({
+    description: 'output raw json'
+  })
 }
 
 RuleDelete.aliases = [

--- a/test/__fixtures__/rule/delete.json
+++ b/test/__fixtures__/rule/delete.json
@@ -1,0 +1,17 @@
+{
+  "action": {
+    "name": "hello",
+    "path": "abcxyz-81khn753xw7jx"
+  },
+  "annotations": [],
+  "name": "r",
+  "namespace": "abcxyz-81khn753xw7jx",
+  "publish": false,
+  "status": "inactive",
+  "trigger": {
+    "name": "t",
+    "path": "abcxyz-81khn753xw7jx"
+  },
+  "updated": 1581455653032,
+  "version": "0.0.1"
+}

--- a/test/commands/runtime/rule/delete.test.js
+++ b/test/commands/runtime/rule/delete.test.js
@@ -76,6 +76,18 @@ describe('instance methods', () => {
         })
     })
 
+    test('delete simple rule with --json', () => {
+      const cmd = ow.mockResolvedFixture(owAction, 'rule/delete.json')
+      command.argv = ['nameFoo', '--json']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name: 'nameFoo'
+          })
+          expect(JSON.parse(stdout.output)).toMatchFixtureJson('rule/delete.json')
+        })
+    })
+
     test('errors out on api error', () => {
       return new Promise((resolve, reject) => {
         ow.mockRejected('rules.delete', new Error('an error'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds `--json` to rule delete and emits API response only when flag is present.

## Related Issue

Fixes #112.
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
