### PR TITLE
Support deploying of blackbox actions

### DIFF
--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -356,10 +356,17 @@ function createActionObject (thisAction, objAction) {
     objAction.action = fs.readFileSync(thisAction['function'], { encoding: 'utf8' })
   }
 
-  objAction.exec = {
-    main: thisAction.main,
-    kind: thisAction.docker ? 'blackbox' : thisAction.runtime,
-    image: thisAction.docker
+  if (thisAction.main || thisAction.docker || thisAction.runtime) {
+    objAction.exec = {}
+    if (thisAction.main) {
+      objAction.exec.main = thisAction.main
+    }
+    if (thisAction.docker) {
+      objAction.exec.kind = 'blackbox'
+      objAction.exec.image = thisAction.docker
+    } else if (thisAction.runtime) {
+      objAction.exec.kind = thisAction.runtime
+    }
   }
 
   if (thisAction.limits) {

--- a/test/__fixtures__/deploy/manifest_docker.yaml
+++ b/test/__fixtures__/deploy/manifest_docker.yaml
@@ -1,0 +1,13 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+# Example: Blackbox action with a custom docker image
+packages:
+  demo_package:
+    actions:
+      sampleAction:
+        function: /deploy/main.js
+        main: split
+        web: false
+        docker: my/docker-image:1.0.0
+

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -96,6 +96,7 @@ describe('instance methods', () => {
       'deploy/manifest_api.yaml': fixtureFile('deploy/manifest_api.yaml'),
       'deploy/manifest_main.yaml': fixtureFile('deploy/manifest_main.yaml'),
       'deploy/manifest_final.yaml': fixtureFile('deploy/manifest_final.yaml'),
+      'deploy/manifest_docker.yaml': fixtureFile('deploy/manifest_docker.yaml'),
       'deploy/manifest_api_incorrect.yaml': fixtureFile('deploy/manifest_api_incorrect.yaml'),
       'deploy/deployment_syncMissingAction.yaml': fixtureFile('deploy/deployment_syncMissingAction.yaml'),
       'deploy/manifest_multiple_packages.yaml': fixtureFile('deploy/manifest_multiple_packages.yaml'),
@@ -353,6 +354,29 @@ describe('instance methods', () => {
               final: true,
               'raw-http': true,
               'require-whisk-auth': true
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('deploys actions with docker image', () => {
+      const cmd = ow.mockResolved(owAction, '')
+      const mainAction = fixtureFile('deploy/main.js')
+      command.argv = ['-m', '/deploy/manifest_docker.yaml']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name: 'demo_package/sampleAction',
+            action: mainAction,
+            annotations: {
+              'raw-http': false,
+              'web-export': false
+            },
+            exec: {
+              image: 'my/docker-image:1.0.0',
+              kind: 'blackbox',
+              main: 'split'
             }
           })
           expect(stdout.output).toMatch('')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The `docker` field in `manifest.yml` is currently ignored. It is needed for deploying blackbox actions. This change sets the right values for the `openwhisk` create action call.

- automatically switch kind to `blackbox` if `docker` is set
- set `image` to value of `docker`
- fix `sequence` type check (now that there is a `blackbox` kind`

## Related Issue

#128 

## Motivation and Context

This is required for Nui.

## How Has This Been Tested?

Unit tests. Manual test deployed against actual openwhisk.

## Screenshots (if appropriate):

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
   - no doc update needed, using standard feature from wskdeploy manifest, field `docker`: https://github.com/apache/openwhisk-wskdeploy/blob/master/specification/html/spec_actions.md#fields
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
