### PR TITLE
require-adobe-auth annotation for web actions in manifest.yaml

### DIFF
--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -414,12 +414,18 @@ function createActionObject (thisAction, objAction) {
  * The annotation will soon be natively supported in Adobe I/O Runtime, at which point
  * this function and references to it can be safely deleted.
  *
+ * @access private
  */
-function _rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
+function rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
   // do not modify those
   const ADOBE_AUTH_ANNOTATION = 'require-adobe-auth'
   const ADOBE_AUTH_ACTION = '/adobeio/shared-validators/ims'
   const REWRITE_ACTION_PREFIX = '__secured_'
+
+  // avoid side effects, do not modify input packages
+  const newPackages = { ...packages }
+  const newDeploymentPackages = { ...deploymentPackages }
+
   // traverse all actions in all packages
   Object.keys(packages).forEach((key) => {
     if (packages[key]['actions']) {
@@ -432,52 +438,75 @@ function _rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
         if (isWeb && thisAction.annotations && thisAction.annotations[ADOBE_AUTH_ANNOTATION]) {
           debug(`found annotation '${ADOBE_AUTH_ANNOTATION}' in action '${key}/${actionName}'`)
 
-          // 1. delete the adobe-auth annotation and secure the renamed action
-          delete thisAction.annotations[ADOBE_AUTH_ANNOTATION]
-          thisAction.annotations['require-whisk-auth'] = true
+          // 0. second level copy
+          newPackages[key] = { ...packages[key] }
+          newDeploymentPackages[key] = { ...deploymentPackages[key] }
 
-          // 2. rename the action
+          // 1. rename the action
           const renamedAction = REWRITE_ACTION_PREFIX + actionName
           /* istanbul ignore if */
           if (packages[key]['actions'][renamedAction] !== undefined) {
             // unlikely
             throw new Error(`Failed to rename the action '${key}/${actionName}' to '${key}/${renamedAction}': an action with the same name exists already.`)
           }
-          // set the action content to the new key
-          packages[key]['actions'][renamedAction] = thisAction
+
+          // copy actions to the new package and move the action content to the new key
+          newPackages[key]['actions'] = {
+            ...packages[key]['actions'],
+            [renamedAction]: { ...thisAction }
+          }
           // delete the old key
-          delete packages[key]['actions'][actionName]
+          delete newPackages[key]['actions'][actionName]
 
           // make sure any content in the deployment package is linked to the new action name
           if (deploymentPackages[key] && deploymentPackages[key]['actions'] && deploymentPackages[key]['actions'][actionName]) {
-            deploymentPackages[key]['actions'][renamedAction] = deploymentPackages[key]['actions'][actionName]
-            delete deploymentPackages[key]['actions'][actionName]
+            newDeploymentPackages[key]['actions'] = {
+              ...deploymentPackages[key]['actions'],
+              [renamedAction]: deploymentPackages[key]['actions'][actionName]
+            }
+            delete newDeploymentPackages[key]['actions'][actionName]
           }
+
+          // 2. delete the adobe-auth annotation and secure the renamed action
+          newPackages[key]['actions'][renamedAction]['annotations'] = {
+            ...packages[key]['actions'][actionName]['annotations'],
+            'require-whisk-auth': true
+          }
+          delete newPackages[key]['actions'][renamedAction]['annotations'][ADOBE_AUTH_ANNOTATION]
+
           debug(`renamed action '${key}/${actionName}' to '${key}/${renamedAction}'`)
 
           // 3. create the sequence
           if (packages[key]['sequences'] === undefined) {
-            packages[key]['sequences'] = {}
-          }
-          /* istanbul ignore if */
-          if (packages[key]['sequences'][actionName] !== undefined) {
+            newPackages[key]['sequences'] = {}
+          } /* istanbul ignore next */ else if (packages[key]['sequences'][actionName] !== undefined) {
             // unlikely
             throw new Error(`The name '${key}/${actionName}' is defined both for an action and a sequence, it should be unique`)
           }
           // set the sequence content
-          packages[key]['sequences'][actionName] = {
-            actions: `${ADOBE_AUTH_ACTION},${key}/${renamedAction}`,
-            web: 'yes'
+          newPackages[key]['sequences'] = {
+            ...packages[key]['sequences'],
+            [actionName]: {
+              actions: `${ADOBE_AUTH_ACTION},${key}/${renamedAction}`,
+              web: 'yes'
+            }
           }
           debug(`defined new sequence '${key}/${actionName}': '${ADOBE_AUTH_ACTION},${key}/${renamedAction}'`)
         }
       })
     }
   })
+  return {
+    newPackages,
+    newDeploymentPackages
+  }
 }
 
 function processPackage (packages, deploymentPackages, deploymentTriggers, params, namesOnly = false) {
-  _rewriteActionsWithAdobeAuthAnnotation(packages, deploymentPackages)
+  // rewrite packages if needed
+  const { newPackages, newDeploymentPackages } = rewriteActionsWithAdobeAuthAnnotation(packages, deploymentPackages)
+  packages = newPackages
+  deploymentPackages = newDeploymentPackages
 
   const pkgAndDeps = []
   const actions = []

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -420,7 +420,6 @@ function _rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
   const ADOBE_AUTH_ANNOTATION = 'require-adobe-auth'
   const ADOBE_AUTH_ACTION = '/adobeio/shared-validators/ims'
   const REWRITE_ACTION_PREFIX = '__secured_'
-
   // traverse all actions in all packages
   Object.keys(packages).forEach((key) => {
     if (packages[key]['actions']) {
@@ -431,6 +430,8 @@ function _rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
 
         // check if the annotation is defined AND the action is a web action
         if (isWeb && thisAction.annotations && thisAction.annotations[ADOBE_AUTH_ANNOTATION]) {
+          debug(`found annotation '${ADOBE_AUTH_ANNOTATION}' in action '${key}/${actionName}'`)
+
           // 1. delete the adobe-auth annotation and secure the renamed action
           delete thisAction.annotations[ADOBE_AUTH_ANNOTATION]
           thisAction.annotations['require-whisk-auth'] = true
@@ -452,6 +453,7 @@ function _rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
             deploymentPackages[key]['actions'][renamedAction] = deploymentPackages[key]['actions'][actionName]
             delete deploymentPackages[key]['actions'][actionName]
           }
+          debug(`renamed action '${key}/${actionName}' to '${key}/${renamedAction}'`)
 
           // 3. create the sequence
           if (packages[key]['sequences'] === undefined) {
@@ -467,6 +469,7 @@ function _rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
             actions: `${ADOBE_AUTH_ACTION},${key}/${renamedAction}`,
             web: 'yes'
           }
+          debug(`defined new sequence '${key}/${actionName}': '${ADOBE_AUTH_ACTION},${key}/${renamedAction}'`)
         }
       })
     }

--- a/test/__fixtures__/deploy/manifest_with_adobe_auth.yaml
+++ b/test/__fixtures__/deploy/manifest_with_adobe_auth.yaml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+# Example: Hello World action using Adobe auth annotation
+packages:
+  testSeq:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      helloAction:
+        function: ./hello.js
+        web: 'yes'
+        annotations:
+          require-adobe-auth: true
+        inputs:
+          name: Elrond
+    sequences:
+      helloSeq:
+        actions: 'testSeq/helloAction,global/fake/action' # testSeq/helloAction will be converted to a seq
+  demo_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      sampleAction:
+        function: ./hello.js
+        web: 'yes'
+        annotations:
+          require-adobe-auth: true
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `require-adobe-auth` allows web actions to be secured using Adobe IMS
 
This is a temporary implementation that rewrites the target web action to a sequence that first executes the /adobeio/shared-validators/ims validator.

 As an example, the following manifest:
```yaml
packages:
  helloworld:
     actions:
       hello:
         function: path/to/hello.js
         web: 'yes'
         require-adobe-auth: true
```
will be deployed as:
```yaml
 packages:
   helloworld:
     actions:
       __secured_hello:
         function: path/to/hello.js
         web: 'yes'
         annotations:
           require-whisk-auth: true #makes sure action cannot be called by itself anymore
     sequences:
       hello:
        actions: '/adobeio/shared-validators/ims,helloworld/__secured_hello'
```

The annotation will be eventually natively supported by Adobe I/O Runtime, at which point
this PR can be safely reverted.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
