### PR TITLE
fix for multiple actions using the require-adobe-auth annotation in the same package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@oclif/plugin-help": "^2.1.6",
     "cli-ux": "^5.2.0",
     "js-yaml": "^3.13.1",
+    "lodash.clonedeep": "^4.5.0",
     "node-fetch": "^2.3.0",
     "openwhisk": "^3.21.1",
     "openwhisk-fqn": "^0.0.2",

--- a/test/__fixtures__/deploy/manifest_with_adobe_auth.yaml
+++ b/test/__fixtures__/deploy/manifest_with_adobe_auth.yaml
@@ -14,6 +14,11 @@ packages:
           require-adobe-auth: true
         inputs:
           name: Elrond
+      helloAction2:
+        function: ./hello.js
+        web: 'yes'
+        annotations:
+          require-adobe-auth: true
     sequences:
       helloSeq:
         actions: 'testSeq/helloAction,global/fake/action' # testSeq/helloAction will be converted to a seq

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -896,16 +896,18 @@ describe('instance methods', () => {
             // pkg1
             // defined sequence (untouched)
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloSeq', action: '', annotations: { 'web-export': false, 'raw-http': false }, exec: { components: ['/ns/testSeq/helloAction', '/global/fake/action'], kind: 'sequence' } })
-            // action
+            // actions
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true }, params: { name: 'Elrond' } })
-            // generated sequence
+            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction2', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true } })
+            // generated sequences
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction'], kind: 'sequence' } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction2', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction2'], kind: 'sequence' } })
             // pkg2
             // action
             expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/__secured_sampleAction', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true } })
             // sequence
             expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleAction', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/demo_package/__secured_sampleAction'], kind: 'sequence' } })
-            expect(cmd).toHaveBeenCalledTimes(5)
+            expect(cmd).toHaveBeenCalledTimes(7)
             expect(stdout.output).toMatch('')
           })
       })
@@ -917,19 +919,21 @@ describe('instance methods', () => {
             // pkg1
             // defined sequence (untouched)
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloSeq', action: '', annotations: { 'web-export': false, 'raw-http': false }, exec: { components: ['/ns/testSeq/helloAction', '/global/fake/action'], kind: 'sequence' } })
-            // action
+            // actions
             // eslint-disable-next-line object-property-newline
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true },
               params: { name: 'Runtime' } // only difference in this test is the changed param
             })
-            // sequence
+            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction2', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true } })
+            // sequences
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction'], kind: 'sequence' } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction2', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction2'], kind: 'sequence' } })
             // pkg2
             // action
             expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/__secured_sampleAction', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true } })
             // sequence
             expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleAction', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/demo_package/__secured_sampleAction'], kind: 'sequence' } })
-            expect(cmd).toHaveBeenCalledTimes(5)
+            expect(cmd).toHaveBeenCalledTimes(7)
             expect(stdout.output).toMatch('')
           })
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The current implementation of require-adobe-auth is not working when multiple actions in the same action use the annotation.
This is a fix for it using lodash.clonedeep.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
