### PR TITLE
Added conductor flag support to manifest annotations

### DIFF
--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -243,6 +243,11 @@ function returnDeploymentTriggerInputs (deploymentPackages) {
 
 function returnAnnotations (action) {
   let annotationParams = {}
+
+  if (action['annotations'] && action['annotations']['conductor'] !== undefined) {
+    annotationParams['conductor'] = action['annotations']['conductor']
+  }
+
   if (action['web'] !== undefined) {
     annotationParams = checkWebFlags(action['web'])
   } else if (action['web-export'] !== undefined) {

--- a/test/__fixtures__/deploy/manifest_conductor.yaml
+++ b/test/__fixtures__/deploy/manifest_conductor.yaml
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+# Example: Basic Hello World using a NodeJS (JavaScript) action
+packages:
+  demo_package:
+    version: 1.0
+    license: Apache-2.0
+    actions:
+      anotherAction:
+        function: /deploy/hello.js
+        annotations:
+            conductor: true
+            raw-http: true

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -95,6 +95,7 @@ describe('instance methods', () => {
       'deploy/manifest_zip.yaml': fixtureFile('deploy/manifest_zip.yaml'),
       'deploy/manifest_api.yaml': fixtureFile('deploy/manifest_api.yaml'),
       'deploy/manifest_main.yaml': fixtureFile('deploy/manifest_main.yaml'),
+      'deploy/manifest_conductor.yaml': fixtureFile('deploy/manifest_conductor.yaml'),
       'deploy/manifest_final.yaml': fixtureFile('deploy/manifest_final.yaml'),
       'deploy/manifest_docker.yaml': fixtureFile('deploy/manifest_docker.yaml'),
       'deploy/manifest_api_incorrect.yaml': fixtureFile('deploy/manifest_api_incorrect.yaml'),
@@ -358,6 +359,23 @@ describe('instance methods', () => {
           })
           expect(stdout.output).toMatch('')
         })
+    })
+
+    test('deploys actions with the conductor annotation', () => {
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = ['-m', '/deploy/manifest_conductor.yaml']
+      return command.run().then(() => {
+        expect(cmd).toHaveBeenCalledWith({
+          name: 'demo_package/anotherAction',
+          action: hello,
+          annotations: {
+            conductor: true,
+            'raw-http': false,
+            'web-export': false
+          }
+        })
+        expect(stdout.output).toMatch('')
+      })
     })
 
     test('deploys actions with docker image', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added conductor flag support in manifest action annotations deployed via `aio-cli-plugin-runtime`.

## Description

Conductor actions make it possible to build and invoke a series of actions, similar to sequences. An action can enabled as a conductor by specifying the conductor annotation:

```
wsk action create myconductor myconductor.js -a conductor true
```

Actions can also be enabled as conductors using a conductor flag in package manifest and when using`wskdeploy`. This PR adds support the same flag support in manifests deployed using `aio-cli-plugin-runtime`.

Below is a sample conductor declaration this PR supports in the manifest.yml file
```
packages:
  __APP_PACKAGE__:
    license: Apache-2.0
    actions:
      conductor-action:
        function: actions/conductor-action/index.js
        runtime: "nodejs:10"
        annotations:
          conductor: true
```

## Related Issue
None

## Motivation and Context

The need to mark actions as conductors is a valuable for writing workflow applications. Without manifest support additional commands must be run after running `aio app deploy`. 

## How Has This Been Tested?

Tested in my own project by flipping between states of it being true, false or not defined

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
