### PR TITLE
harden implementation of require-adobe-auth annotation

### DIFF
--- a/src/RuntimeBaseCommand.js
+++ b/src/RuntimeBaseCommand.js
@@ -20,7 +20,7 @@ const OpenWhisk = require('openwhisk')
 const config = require('@adobe/aio-lib-core-config')
 
 class RuntimeBaseCommand extends Command {
-  async wsk () {
+  async getOptions () {
     const { flags } = this.parse(this.constructor)
     const properties = propertiesFile()
 
@@ -59,6 +59,13 @@ class RuntimeBaseCommand extends Command {
       process.env['__OW_USER_AGENT'] = flags.useragent
     }
 
+    return options
+  }
+
+  async wsk (options) {
+    if (!options) {
+      options = await this.getOptions()
+    }
     return OpenWhisk(options)
   }
 

--- a/src/commands/runtime/deploy/index.js
+++ b/src/commands/runtime/deploy/index.js
@@ -30,9 +30,9 @@ class IndexCommand extends RuntimeBaseCommand {
       } else if (flags['param-file']) {
         params = createKeyValueObjectFromFile(flags['param-file'])
       }
-
-      const entities = processPackage(packages, deploymentPackages, deploymentTriggers, params)
-      const ow = await this.wsk()
+      const options = await this.getOptions()
+      const entities = processPackage(packages, deploymentPackages, deploymentTriggers, params, false, options)
+      const ow = await this.wsk(options)
       const logger = this.log
       await deployPackage(entities, ow, logger)
     } catch (err) {

--- a/src/commands/runtime/deploy/sync.js
+++ b/src/commands/runtime/deploy/sync.js
@@ -27,8 +27,9 @@ class DeploySync extends RuntimeBaseCommand {
         throw new Error('The mandatory key [project name] is missing')
       }
       const params = {}
-      const entities = processPackage(packages, deploymentPackages, deploymentTriggers, params)
-      const ow = await this.wsk()
+      const options = await this.getOptions()
+      const entities = processPackage(packages, deploymentPackages, deploymentTriggers, params, false, options)
+      const ow = await this.wsk(options)
       const logger = this.log
       await syncProject(components.projectName, components.manifestPath, components.manifestContent, entities, ow, logger)
     } catch (err) {

--- a/src/commands/runtime/deploy/undeploy.js
+++ b/src/commands/runtime/deploy/undeploy.js
@@ -18,7 +18,8 @@ class DeployUndeploy extends RuntimeBaseCommand {
   async run () {
     const { flags } = this.parse(DeployUndeploy)
     try {
-      const ow = await this.wsk()
+      const options = await this.getOptions()
+      const ow = await this.wsk(options)
       const logger = this.log
 
       let entities
@@ -32,7 +33,7 @@ class DeployUndeploy extends RuntimeBaseCommand {
         // todo support deployment files
         const deploymentTriggers = {} // components.deploymentTriggers
         const deploymentPackages = {} // components.deploymentPackages
-        entities = processPackage(packages, deploymentTriggers, deploymentPackages, {}, true) // true for getting entity namesOnly, we do not need to parse all actions files and so on
+        entities = processPackage(packages, deploymentTriggers, deploymentPackages, {}, true, options) // true for getting entity namesOnly, we do not need to parse all actions files and so on
       }
 
       await undeployPackage(entities, ow, logger)

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -433,10 +433,12 @@ function rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
       Object.keys(newPackages[key]['actions']).forEach((actionName) => {
         const thisAction = newPackages[key]['actions'][actionName]
 
-        const isWeb = checkWebFlags(thisAction['web-export'])['web-export'] || checkWebFlags(thisAction['web'])['web-export']
+        const isWebExport = checkWebFlags(thisAction['web-export'])['web-export']
+        const isWeb = checkWebFlags(thisAction['web'])['web-export']
+        const isRaw = checkWebFlags(thisAction['web'])['raw-http'] || checkWebFlags(thisAction['web-export'])['raw-http']
 
         // check if the annotation is defined AND the action is a web action
-        if (isWeb && thisAction.annotations && thisAction.annotations[ADOBE_AUTH_ANNOTATION]) {
+        if ((isWeb || isWebExport) && thisAction.annotations && thisAction.annotations[ADOBE_AUTH_ANNOTATION]) {
           debug(`found annotation '${ADOBE_AUTH_ANNOTATION}' in action '${key}/${actionName}'`)
 
           // 1. rename the action
@@ -459,7 +461,13 @@ function rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
           }
 
           // 2. delete the adobe-auth annotation and secure the renamed action
-          newPackages[key]['actions'][renamedAction]['annotations']['require-whisk-auth'] = true
+          // the renamed action is made secure by removing its web property
+          if (isWeb) {
+            newPackages[key]['actions'][renamedAction]['web'] = false
+          }
+          if (isWebExport) {
+            newPackages[key]['actions'][renamedAction]['web-export'] = false
+          }
           delete newPackages[key]['actions'][renamedAction]['annotations'][ADOBE_AUTH_ANNOTATION]
 
           debug(`renamed action '${key}/${actionName}' to '${key}/${renamedAction}'`)
@@ -476,7 +484,7 @@ function rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
           // set the sequence content
           newPackages[key]['sequences'][actionName] = {
             actions: `${ADOBE_AUTH_ACTION},${key}/${renamedAction}`,
-            web: 'yes'
+            web: (isRaw && 'raw') || 'yes'
           }
 
           debug(`defined new sequence '${key}/${actionName}': '${ADOBE_AUTH_ACTION},${key}/${renamedAction}'`)

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -498,11 +498,14 @@ function rewriteActionsWithAdobeAuthAnnotation (packages, deploymentPackages) {
   }
 }
 
-function processPackage (packages, deploymentPackages, deploymentTriggers, params, namesOnly = false) {
-  // rewrite packages if needed
-  const { newPackages, newDeploymentPackages } = rewriteActionsWithAdobeAuthAnnotation(packages, deploymentPackages)
-  packages = newPackages
-  deploymentPackages = newDeploymentPackages
+function processPackage (packages, deploymentPackages, deploymentTriggers, params, namesOnly = false, owOptions = {}) {
+  if (owOptions.apihost === 'https://adobeioruntime.net') {
+    // rewrite packages in case there are any `require-adobe-auth` annotations
+    // this is a temporary feature and will be replaced by a native support in Adobe I/O Runtime
+    const { newPackages, newDeploymentPackages } = rewriteActionsWithAdobeAuthAnnotation(packages, deploymentPackages)
+    packages = newPackages
+    deploymentPackages = newDeploymentPackages
+  }
 
   const pkgAndDeps = []
   const actions = []

--- a/test/__fixtures__/deploy/manifest_with_adobe_auth.yaml
+++ b/test/__fixtures__/deploy/manifest_with_adobe_auth.yaml
@@ -9,7 +9,7 @@ packages:
     actions:
       helloAction:
         function: ./hello.js
-        web: 'yes'
+        web-export: 'yes'
         annotations:
           require-adobe-auth: true
         inputs:
@@ -28,7 +28,7 @@ packages:
     actions:
       sampleAction:
         function: ./hello.js
-        web: 'yes'
+        web-export: 'raw'
         annotations:
           require-adobe-auth: true
 

--- a/test/__fixtures__/deploy/manifest_with_adobe_auth.yaml
+++ b/test/__fixtures__/deploy/manifest_with_adobe_auth.yaml
@@ -31,4 +31,13 @@ packages:
         web-export: 'raw'
         annotations:
           require-adobe-auth: true
-
+      sampleActionNoAnnotation:
+        function: ./hello.js
+        web-export: 'yes'
+      sampleActionNoWeb:
+        function: ./hello.js
+        annotations:
+          require-adobe-auth: true
+  no_actions_pkg:
+    version: 1.0
+    license: Apache-2.0

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -897,16 +897,16 @@ describe('instance methods', () => {
             // defined sequence (untouched)
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloSeq', action: '', annotations: { 'web-export': false, 'raw-http': false }, exec: { components: ['/ns/testSeq/helloAction', '/global/fake/action'], kind: 'sequence' } })
             // actions
-            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true }, params: { name: 'Elrond' } })
-            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction2', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction', action: hello, annotations: { 'web-export': false, 'raw-http': false }, params: { name: 'Elrond' } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction2', action: hello, annotations: { 'web-export': false, 'raw-http': false } })
             // generated sequences
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction'], kind: 'sequence' } })
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction2', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction2'], kind: 'sequence' } })
             // pkg2
             // action
-            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/__secured_sampleAction', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/__secured_sampleAction', action: hello, annotations: { 'web-export': false, 'raw-http': false } })
             // sequence
-            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleAction', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/demo_package/__secured_sampleAction'], kind: 'sequence' } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleAction', action: '', annotations: { 'web-export': true, 'raw-http': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/demo_package/__secured_sampleAction'], kind: 'sequence' } })
             expect(cmd).toHaveBeenCalledTimes(7)
             expect(stdout.output).toMatch('')
           })
@@ -921,18 +921,18 @@ describe('instance methods', () => {
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloSeq', action: '', annotations: { 'web-export': false, 'raw-http': false }, exec: { components: ['/ns/testSeq/helloAction', '/global/fake/action'], kind: 'sequence' } })
             // actions
             // eslint-disable-next-line object-property-newline
-            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true },
+            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction', action: hello, annotations: { 'web-export': false, 'raw-http': false },
               params: { name: 'Runtime' } // only difference in this test is the changed param
             })
-            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction2', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/__secured_helloAction2', action: hello, annotations: { 'web-export': false, 'raw-http': false } })
             // sequences
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction'], kind: 'sequence' } })
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction2', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction2'], kind: 'sequence' } })
             // pkg2
             // action
-            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/__secured_sampleAction', action: hello, annotations: { 'web-export': true, 'require-whisk-auth': true } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/__secured_sampleAction', action: hello, annotations: { 'web-export': false, 'raw-http': false } })
             // sequence
-            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleAction', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/demo_package/__secured_sampleAction'], kind: 'sequence' } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleAction', action: '', annotations: { 'web-export': true, 'raw-http': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/demo_package/__secured_sampleAction'], kind: 'sequence' } })
             expect(cmd).toHaveBeenCalledTimes(7)
             expect(stdout.output).toMatch('')
           })

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -888,9 +888,33 @@ describe('instance methods', () => {
           'deploy/manifest_with_adobe_auth.yaml': fixtureFile('deploy/manifest_with_adobe_auth.yaml')
         })
       })
+
+      test('processPackage with no owOptions', () => {
+        // for coverage..
+        // should not rewrite
+        const helpers = require('../../../../src/runtime-helpers')
+        const res = helpers.processPackage({
+          hello: { actions: { helloAction: { function: 'hello.js', annotations: { 'require-adobe-auth': true } } } }
+        }, {}, {}, {})
+        expect(res).toEqual(expect.objectContaining({ actions: [expect.objectContaining({ name: 'hello/helloAction', annotations: { 'web-export': false, 'raw-http': false } })] }))
+      })
+
+      test('ignores require-adobe-auth annotation if apihost is not I/O Runtime', () => {
+        const cmd = ow.mockResolved(owAction, '')
+        command.argv = ['-m', 'manifest_with_adobe_auth.yaml', '--apihost', 'https://not.runtime.net']
+        return command.run()
+          .then(() => {
+            cmd.mock.calls.forEach(call => {
+              expect(call[0]).not.toEqual(expect.objectContaining({
+                name: expect.stringContaining('__secured')
+              }))
+            })
+            expect(cmd).toHaveBeenCalledTimes(6)
+          })
+      })
       test('deploys web action with require-adobe-auth annotation', () => {
         const cmd = ow.mockResolved(owAction, '')
-        command.argv = ['-m', 'manifest_with_adobe_auth.yaml']
+        command.argv = ['-m', 'manifest_with_adobe_auth.yaml', '--apihost', 'https://adobeioruntime.net']
         return command.run()
           .then(() => {
             // pkg1
@@ -904,16 +928,18 @@ describe('instance methods', () => {
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction2', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction2'], kind: 'sequence' } })
             // pkg2
             // action
+            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleActionNoAnnotation', action: hello, annotations: { 'web-export': true } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleActionNoWeb', action: hello, annotations: { 'web-export': false, 'raw-http': false } })
             expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/__secured_sampleAction', action: hello, annotations: { 'web-export': false, 'raw-http': false } })
             // sequence
             expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleAction', action: '', annotations: { 'web-export': true, 'raw-http': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/demo_package/__secured_sampleAction'], kind: 'sequence' } })
-            expect(cmd).toHaveBeenCalledTimes(7)
+            expect(cmd).toHaveBeenCalledTimes(9)
             expect(stdout.output).toMatch('')
           })
       })
       test('deploys web action with require-adobe-auth annotation and deployment.yaml', () => {
         const cmd = ow.mockResolved(owAction, '')
-        command.argv = ['-m', 'manifest_with_adobe_auth.yaml', '-d', 'deployment_correctpackage.yaml']
+        command.argv = ['-m', 'manifest_with_adobe_auth.yaml', '-d', 'deployment_correctpackage.yaml', '--apihost', 'https://adobeioruntime.net']
         return command.run()
           .then(() => {
             // pkg1
@@ -930,10 +956,12 @@ describe('instance methods', () => {
             expect(cmd).toHaveBeenCalledWith({ name: 'testSeq/helloAction2', action: '', annotations: { 'web-export': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/testSeq/__secured_helloAction2'], kind: 'sequence' } })
             // pkg2
             // action
+            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleActionNoAnnotation', action: hello, annotations: { 'web-export': true } })
+            expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleActionNoWeb', action: hello, annotations: { 'web-export': false, 'raw-http': false } })
             expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/__secured_sampleAction', action: hello, annotations: { 'web-export': false, 'raw-http': false } })
             // sequence
             expect(cmd).toHaveBeenCalledWith({ name: 'demo_package/sampleAction', action: '', annotations: { 'web-export': true, 'raw-http': true }, exec: { components: ['/adobeio/shared-validators/ims', '/ns/demo_package/__secured_sampleAction'], kind: 'sequence' } })
-            expect(cmd).toHaveBeenCalledTimes(7)
+            expect(cmd).toHaveBeenCalledTimes(9)
             expect(stdout.output).toMatch('')
           })
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- secure original action by making them non web instead of using require-whisk-auth (which allowed every valid namespace to access the action!)
- support for raw-http actions
- only rewrite actions when the  apihost is `adobeioruntime.net`. The current implementation will break other openwhisk deployments such as in a local dev stack. This is because the validation action /adobeio/shared-validators/ims is only available in Adobe I/O Runtime

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
