### PR TITLE
add header to invoke for extra logging, this closes #146

### DIFF
--- a/src/commands/runtime/action/invoke.js
+++ b/src/commands/runtime/action/invoke.js
@@ -32,7 +32,8 @@ class ActionInvoke extends RuntimeBaseCommand {
         name,
         params: paramsAction,
         blocking: flags.blocking || flags.result,
-        result: flags.result
+        result: flags.result,
+        headers: { 'X-OW-EXTRA-LOGGING': 'on' }
       })
       this.logJSON('', result)
     } catch (err) {

--- a/test/commands/runtime/action/invoke.test.js
+++ b/test/commands/runtime/action/invoke.test.js
@@ -75,7 +75,24 @@ describe('instance methods', () => {
       command.argv = ['hello']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ name: 'hello', blocking: false, params: {}, result: false })
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
+            name: 'hello',
+            blocking: false,
+            params: {},
+            result: false
+          }))
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('sets X-OW-EXTRA-LOGGING header when invoking an action', () => {
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = ['hello']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
+            headers: expect.objectContaining({ 'X-OW-EXTRA-LOGGING': 'on' })
+          }))
           expect(stdout.output).toMatch('')
         })
     })
@@ -85,12 +102,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--param', 'a', 'b', 'c', 'd']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             params: { a: 'b', c: 'd' },
             blocking: false,
             result: false
-          })
+          }))
           expect(stdout.output).toMatch('')
         })
     })
@@ -100,12 +117,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--param', 'a', 'b', '--param', 'c', 'd', '--blocking']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             params: { a: 'b', c: 'd' },
             blocking: true,
             result: false
-          })
+          }))
           expect(stdout.output).toMatch('')
         })
     })
@@ -115,12 +132,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--result']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             blocking: true,
             params: {},
             result: true
-          })
+          }))
           expect(stdout.output).toMatch('')
         })
     })
@@ -131,12 +148,12 @@ describe('instance methods', () => {
       command.argv = ['hello']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             blocking: false,
             params: {},
             result: false
-          })
+          }))
           expect(stdout.output).toMatch(JSON.stringify(result, null, 2))
         })
     })
@@ -147,12 +164,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--blocking']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             blocking: true,
             params: {},
             result: false
-          })
+          }))
           expect(stdout.output).toMatch(JSON.stringify(result, null, 2))
         })
     })
@@ -163,12 +180,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--result']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             blocking: true,
             params: {},
             result: true
-          })
+          }))
           expect(stdout.output).toMatch(JSON.stringify(result, null, 2))
         })
     })
@@ -180,12 +197,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--blocking']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             blocking: true,
             params: {},
             result: false
-          })
+          }))
 
           expect(stdout.output).toMatch(`activation took too long, use activation id 123456 to check for completion.`)
         })
@@ -198,12 +215,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--result']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             blocking: true,
             params: {},
             result: true
-          })
+          }))
 
           expect(stdout.output).toMatch(`activation took too long, use activation id 123456 to check for completion.`)
         })
@@ -217,12 +234,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--blocking']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             blocking: true,
             params: {},
             result: false
-          })
+          }))
 
           expect(stdout.output).toMatch(JSON.stringify(result, null, 2))
         })
@@ -237,12 +254,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--result']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             blocking: true,
             params: {},
             result: true
-          })
+          }))
 
           expect(stdout.output).toMatch(JSON.stringify(result.response.result, null, 2))
         })
@@ -253,12 +270,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--param', 'a', 'b', '--param', 'c', 'd', '--blocking', '--result']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             params: { a: 'b', c: 'd' },
             blocking: true,
             result: true
-          })
+          }))
           expect(stdout.output).toMatch('')
         })
     })
@@ -274,12 +291,12 @@ describe('instance methods', () => {
       command.argv = ['hello', '--param-file', '/action/parameters.json', '--blocking', '--result']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({
             name: 'hello',
             params: { param1: 'param1value', param2: 'param2value' },
             blocking: true,
             result: true
-          })
+          }))
           expect(stdout.output).toMatch('')
         })
     })


### PR DESCRIPTION

## Description
Add {X-OW-EXTRA-LOGGING: on} header to all action invoke calls from `aio rt`

## Related Issue
See issue #146

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
