### PR TITLE
Fix issues related to parsing of package name.

### DIFF
--- a/src/commands/runtime/action/list.js
+++ b/src/commands/runtime/action/list.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
+const { parsePackageName } = require('../../../runtime-helpers')
 const { flags } = require('@oclif/command')
 const { cli } = require('cli-ux')
 
@@ -20,10 +21,12 @@ class ActionList extends RuntimeBaseCommand {
     const options = {
       ...flags
     }
-    if (args.package) {
-      options.id = `${args.package}/`
-    }
     try {
+      if (args.packageName) {
+        const { namespace, name } = parsePackageName(args.packageName)
+        options.namespace = namespace
+        options.id = `${name}/`
+      }
       const ow = await this.wsk()
       const result = await ow.actions.list(options)
       if (flags['name-sort'] || flags.name) {
@@ -59,7 +62,7 @@ class ActionList extends RuntimeBaseCommand {
 
 ActionList.args = [
   {
-    name: 'package',
+    name: 'packageName',
     required: false
   }
 ]

--- a/src/commands/runtime/package/delete.js
+++ b/src/commands/runtime/package/delete.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
+const { parsePackageName } = require('../../../runtime-helpers')
 const { flags } = require('@oclif/command')
 
 class PackageDelete extends RuntimeBaseCommand {
@@ -18,8 +19,9 @@ class PackageDelete extends RuntimeBaseCommand {
     const { args, flags } = this.parse(PackageDelete)
     try {
       const ow = await this.wsk()
+      const options = parsePackageName(args.packageName)
       // Packages can be deleted only when there are no actions inside the packages
-      const result = await ow.packages.delete(args.packageName)
+      const result = await ow.packages.delete(options)
       if (flags.json) {
         this.logJSON('', result)
       }

--- a/src/commands/runtime/package/get.js
+++ b/src/commands/runtime/package/get.js
@@ -11,14 +11,14 @@ governing permissions and limitations under the License.
 */
 
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
+const { parsePackageName } = require('../../../runtime-helpers')
 
 class PackageGet extends RuntimeBaseCommand {
   async run () {
     const { args } = this.parse(PackageGet)
     try {
       const ow = await this.wsk()
-      const options = {}
-      options['name'] = args.packageName
+      const options = parsePackageName(args.packageName)
       const result = await ow.packages.get(options)
       this.logJSON('', result)
     } catch (err) {
@@ -33,6 +33,10 @@ PackageGet.args = [
     required: true
   }
 ]
+
+PackageGet.flags = {
+  ...RuntimeBaseCommand.flags
+}
 
 PackageGet.description = 'Retrieves a Package'
 

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -127,6 +127,31 @@ function createKeyValueObjectFromFlag (flag) {
     throw (new Error('Please provide correct values for flags'))
   }
 }
+
+/**
+ * @description parses a string and returns the namespace and entity name for a package.
+ * @returns An object { namespace: string, name: string }
+ */
+function parsePackageName (name) {
+  const delimiter = '/'
+  const parts = name.split(delimiter)
+  let n = parts.length
+  const leadingSlash = name[0] === delimiter
+  // accept no more than [/]ns/p
+  // these are all valid entries [/]ns/p, p, [/]_/p
+  if (n < 1 || n > 3 || (leadingSlash && n === 2) || (!leadingSlash && n === 3)) throw (new Error('Package name is not valid'))
+  // skip leading slash, all parts must be non empty (could tighten this check to match EntityName regex)
+  parts.forEach(function (part, i) { if (i > 0 && part.trim().length === 0) throw (new Error('Package name is not valid')) })
+  if (leadingSlash) {
+    parts.shift() // drop leading slash
+    n--
+  }
+  return {
+    namespace: n === 2 ? parts[0] : '_',
+    name: n === 1 ? parts[0] : parts[1]
+  }
+}
+
 /**
  * @description returns key value pairs from the parameters supplied. Used to create --param-file and --annotation-file key value pairs
  * @param file : flags['param-file'] or flags['annotation-file']
@@ -1067,6 +1092,7 @@ module.exports = {
   createKeyValueObjectFromFlag,
   createKeyValueObjectFromFile,
   parsePathPattern,
+  parsePackageName,
   createComponentsfromSequence,
   processInputs,
   createKeyValueInput,

--- a/test/commands/runtime/action/list.test.js
+++ b/test/commands/runtime/action/list.test.js
@@ -92,6 +92,16 @@ describe('instance methods', () => {
         })
     })
 
+    test('return list of actions in a package in /ns', () => {
+      const cmd = ow.mockResolvedFixture(owAction, 'action/list.json')
+      command.argv = ['/ns/somepackage']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith(expect.objectContaining({ namespace: 'ns', id: 'somepackage/' }))
+          expect(stdout.output).toMatchFixture('action/list-output.txt')
+        })
+    })
+
     test('return list of actions - coverage (public/private)', () => {
       const json = fixtureJson('action/list.json')
       json[0].publish = true
@@ -122,6 +132,30 @@ describe('instance methods', () => {
           expect(cmd).toHaveBeenCalledWith(expect.objectContaining({ skip: 3 }))
           expect(stdout.output).toMatch('actions')
         })
+    })
+
+    test('reject invalid package name /', () => {
+      return new Promise((resolve, reject) => {
+        command.argv = ['/']
+        return command.run()
+          .then(() => reject(new Error('does not throw error')))
+          .catch(() => {
+            expect(handleError).toHaveBeenLastCalledWith('failed to list the actions', new Error('Package name is not valid'))
+            resolve()
+          })
+      })
+    })
+
+    test('reject invalid package name //', () => {
+      return new Promise((resolve, reject) => {
+        command.argv = ['//']
+        return command.run()
+          .then(() => reject(new Error('does not throw error')))
+          .catch(() => {
+            expect(handleError).toHaveBeenLastCalledWith('failed to list the actions', new Error('Package name is not valid'))
+            resolve()
+          })
+      })
     })
 
     test('errors out on api error', () => {

--- a/test/commands/runtime/package/delete.test.js
+++ b/test/commands/runtime/package/delete.test.js
@@ -56,7 +56,17 @@ describe('instance methods', () => {
       command.argv = ['packageName']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith('packageName')
+          expect(cmd).toHaveBeenCalledWith({ namespace: '_', name: 'packageName' })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('delete a package /ns', () => {
+      const cmd = ow.mockResolved(owAction, '')
+      command.argv = ['ns/packageName']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({ namespace: 'ns', name: 'packageName' })
           expect(stdout.output).toMatch('')
         })
     })
@@ -66,7 +76,7 @@ describe('instance methods', () => {
       command.argv = ['packageName', '--json']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith('packageName')
+          expect(cmd).toHaveBeenCalledWith({ namespace: '_', name: 'packageName' })
           expect(stdout.output).toMatch('')
         })
     })

--- a/test/commands/runtime/package/get.test.js
+++ b/test/commands/runtime/package/get.test.js
@@ -14,7 +14,7 @@ const { stdout } = require('stdout-stderr')
 const TheCommand = require('../../../../src/commands/runtime/package/get.js')
 const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand.js')
 const ow = require('openwhisk')()
-const owAction = 'packages.get'
+const owPackage = 'packages.get'
 
 test('exports', async () => {
   expect(typeof TheCommand).toEqual('function')
@@ -52,18 +52,28 @@ describe('instance methods', () => {
     })
 
     test('retrieve a package', () => {
-      const cmd = ow.mockResolved(owAction, '')
+      const cmd = ow.mockResolved(owPackage, '')
       command.argv = ['packageName']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ name: 'packageName' })
+          expect(cmd).toHaveBeenCalledWith({ namespace: '_', name: 'packageName' })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('retrieve a package in namespace', () => {
+      const cmd = ow.mockResolved(owPackage, '')
+      command.argv = ['ns/packageName']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({ namespace: 'ns', name: 'packageName' })
           expect(stdout.output).toMatch('')
         })
     })
 
     test('errors out on api error', () => {
       return new Promise((resolve, reject) => {
-        ow.mockRejected(owAction, new Error('an error'))
+        ow.mockRejected(owPackage, new Error('an error'))
         command.argv = ['packageName']
         return command.run()
           .then(() => reject(new Error('does not throw error')))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

    Fix issues related to parsing of package name.
    
    Action list, package delete/bind/get now properly parse the package name of
    the format [[/]ns/]pkg.
    
    Also fixes --verbose/-v flags on package get.

## Related Issue

Closes #123.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
