### PR TITLE
Adding support for shared packages

### DIFF
--- a/src/commands/runtime/deploy/export.js
+++ b/src/commands/runtime/deploy/export.js
@@ -100,6 +100,9 @@ async function createProjectJSON (entities, projectname, ow, fileDirectory) {
       sequences: {},
       rules: {}
     }
+    if (pkg.publish) {
+      project['packages'][pkg.name]['public'] = pkg.publish
+    }
   }
 
   const filesObject = []

--- a/src/commands/runtime/deploy/report.js
+++ b/src/commands/runtime/deploy/report.js
@@ -31,7 +31,11 @@ class DeployReport extends RuntimeBaseCommand {
       const actions = []
       const triggers = []
       Object.keys(packages).forEach((key) => {
-        pkg.push({ name: key, Inputs: {} })
+        const objPkg = { name: key, Inputs: {} }
+        if (packages[key]['public']) {
+          objPkg.public = packages[key]['public']
+        }
+        pkg.push(objPkg)
         if (packages[key]['actions']) {
           Object.keys(packages[key]['actions']).forEach((action) => {
             const objAction = { name: action, Inputs: {} }

--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -608,7 +608,12 @@ function processPackage (packages, deploymentPackages, deploymentTriggers, param
   const arrSequence = []
 
   Object.keys(packages).forEach((key) => {
-    pkgAndDeps.push({ name: key })
+    const objPackage = { name: key }
+    if (packages[key]['public']) {
+      objPackage['package'] = { publish: packages[key]['public'] }
+    }
+    pkgAndDeps.push(objPackage)
+
     // From wskdeploy repo : currently, the 'version' and 'license' values are not stored in Apache OpenWhisk, but there are plans to support it in the future
     // pkg.version = packages[key]['version']
     // pkg.license = packages[key]['license']

--- a/test/__fixtures__/deploy/manifest.yaml
+++ b/test/__fixtures__/deploy/manifest.yaml
@@ -17,3 +17,5 @@ packages:
   demo_package_no_actions:
     version: 1.0
     license: Apache-2.0
+  demo_package_shared:
+    public: true

--- a/test/__fixtures__/deploy/manifest_multiple_packages.yaml
+++ b/test/__fixtures__/deploy/manifest_multiple_packages.yaml
@@ -32,3 +32,7 @@ packages:
     triggers:
       meetPerson2:
         inputs:
+  sharedpack1:
+    public: true
+  sharedpack2:
+    public: false

--- a/test/__fixtures__/deploy/report_packages.txt
+++ b/test/__fixtures__/deploy/report_packages.txt
@@ -11,6 +11,11 @@
   "Inputs": {}
 }
 {
+  "name": "demo_package_shared",
+  "Inputs": {},
+  "public": true
+}
+{
   "name": "sampleAction",
   "Inputs": {
     "name": "Adobe",

--- a/test/commands/runtime/deploy/export.test.js
+++ b/test/commands/runtime/deploy/export.test.js
@@ -54,6 +54,24 @@ describe('instance methods', () => {
     version: '0.0.2'
   }]
 
+  const sharedPackagelist = [{
+    annotations: [{
+      key: 'whisk-managed',
+      value: {
+        file: 'manifest.yaml',
+        projectDeps: [],
+        projectHash: 'xyz',
+        projectName: 'proj'
+      }
+    }],
+    binding: false,
+    name: 'testSeq',
+    namespace: 'ns',
+    publish: true,
+    updated: 1555533204836,
+    version: '0.0.2'
+  }]
+
   const packageNoAnnotations = [{
     annotations: [],
     binding: false,
@@ -77,6 +95,17 @@ describe('instance methods', () => {
     version: '0.0.2'
   }]
 
+  const emptyPackage = {
+    actions: [],
+    annotations: [],
+    binding: {},
+    feeds: [],
+    name: 'testSeq',
+    namespace: 'ns',
+    parameters: [],
+    publish: false,
+    version: '0.0.2'
+  }
   const packageget = {
     actions: [{
       annotations: [],
@@ -431,6 +460,20 @@ describe('instance methods', () => {
       return command.run()
         .then(() => {
           expect(cmd).toHaveBeenCalled()
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('fetch list of packages (shared) to be exported from project name', () => {
+      const cmd = ow.mockResolved('packages.get', emptyPackage)
+      command.argv = ['--projectname', 'proj', '-m', '/deploy/manifest.yaml']
+      ow.mockResolved(owPackageList, sharedPackagelist)
+      ow.mockResolved('actions.get', '')
+      fs.writeFileSync = jest.fn()
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalled()
+          expect(fs.writeFileSync).toHaveBeenCalledWith('/deploy/manifest.yaml', expect.stringContaining('public: true'))
           expect(stdout.output).toMatch('')
         })
     })

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -221,7 +221,28 @@ describe('instance methods', () => {
       command.argv = ['-m', '/deploy/manifest_multiple_packages.yaml', '--deployment', '/deploy/deployment.yaml']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledTimes(2)
+          expect(cmd).toHaveBeenCalledTimes(4)
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('shared packages should be created', () => {
+      const cmd = ow.mockResolved(owPackage, '')
+      command.argv = ['-m', '/deploy/manifest_multiple_packages.yaml', '--deployment', '/deploy/deployment.yaml']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledTimes(4)
+          expect(cmd).toHaveBeenCalledWith(expect.anything())
+          expect(cmd).toHaveBeenCalledWith(expect.anything())
+          expect(cmd).toHaveBeenCalledWith({
+            name: 'sharedpack1',
+            package: {
+              publish: true
+            }
+          })
+          expect(cmd).toHaveBeenLastCalledWith({
+            name: 'sharedpack2'
+          })
           expect(stdout.output).toMatch('')
         })
     })

--- a/test/commands/runtime/deploy/report.test.js
+++ b/test/commands/runtime/deploy/report.test.js
@@ -110,7 +110,7 @@ describe('instance methods', () => {
       command.argv = []
       return command.run()
         .then(() => {
-          expect(stdout.output).toMatchFixture('deploy/report_twoPackages.txt')
+          expect(stdout.output).toMatchFixture('deploy/report_packages.txt')
         })
     })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes https://github.com/adobe/aio-cli-plugin-runtime/issues/132
Now shared packages can be deployed/undeployed/synced/exported using manifest file.
eg:-
```
packages:
  my-package:
    public: true
    [...]
```
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aio-cli-plugin-runtime/issues/132
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
