### PR TITLE
Support setting action concurrency in manifest #176

### DIFF
--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -465,6 +465,9 @@ function createActionObject (thisAction, objAction) {
       logs: thisAction.limits['logSize'] || 10,
       timeout: thisAction.limits['timeout'] || 60000
     }
+    if (thisAction.limits.concurrency) {
+      limits.concurrency = thisAction.limits.concurrency
+    }
     objAction['limits'] = limits
   }
   objAction['annotations'] = returnAnnotations(thisAction)

--- a/test/__fixtures__/deploy/manifest_concurrency.yaml
+++ b/test/__fixtures__/deploy/manifest_concurrency.yaml
@@ -1,7 +1,7 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more contributor
 # license agreements; and to You under the Apache License, Version 2.0.
 
-# Example: Blackbox action with a custom docker image
+# Example: set custom action concurrency
 packages:
   demo_package:
     actions:

--- a/test/__fixtures__/deploy/manifest_concurrency.yaml
+++ b/test/__fixtures__/deploy/manifest_concurrency.yaml
@@ -1,0 +1,12 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
+# Example: Blackbox action with a custom docker image
+packages:
+  demo_package:
+    actions:
+      sampleAction:
+        function: /deploy/main.js
+        limits:
+          concurrency: 10
+

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -101,6 +101,7 @@ describe('instance methods', () => {
       'deploy/manifest_conductor.yaml': fixtureFile('deploy/manifest_conductor.yaml'),
       'deploy/manifest_final.yaml': fixtureFile('deploy/manifest_final.yaml'),
       'deploy/manifest_docker.yaml': fixtureFile('deploy/manifest_docker.yaml'),
+      'deploy/manifest_concurrency.yaml': fixtureFile('deploy/manifest_concurrency.yaml'),
       'deploy/manifest_api_incorrect.yaml': fixtureFile('deploy/manifest_api_incorrect.yaml'),
       'deploy/deployment_syncMissingAction.yaml': fixtureFile('deploy/deployment_syncMissingAction.yaml'),
       'deploy/manifest_multiple_packages.yaml': fixtureFile('deploy/manifest_multiple_packages.yaml'),
@@ -398,6 +399,30 @@ describe('instance methods', () => {
               image: 'my/docker-image:1.0.0',
               kind: 'blackbox',
               main: 'split'
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('deploys actions with concurrency limit', () => {
+      const cmd = ow.mockResolved(owAction, '')
+      const mainAction = fixtureFile('deploy/main.js')
+      command.argv = ['-m', '/deploy/manifest_concurrency.yaml']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith({
+            name: 'demo_package/sampleAction',
+            action: mainAction,
+            annotations: {
+              'raw-http': false,
+              'web-export': false
+            },
+            limits: {
+              concurrency: 10,
+              logs: 10,
+              memory: 256,
+              timeout: 60000
             }
           })
           expect(stdout.output).toMatch('')


### PR DESCRIPTION
## Description

Fixes https://github.com/adobe/aio-cli-plugin-runtime/issues/176

To discuss: the name choice of `concurrency`. The [openwhisk manifest spec](https://github.com/apache/openwhisk-wskdeploy/blob/master/specification/html/spec_actions.md#valid-limit-keys) does not include it yet (note that `concurrentActivations` is a _different_ limit). I simply used the same name as used in the OpenWhisk API & `wsk`.

## How Has This Been Tested?

- unit test
- deployed example action in production with `concurrency` set in manifest.yml  and tested that `wsk action get <action>` shows the `concurrency` limit

manifest.yml:
```
packages:
  __APP_PACKAGE__:
    license: Apache-2.0
    actions:
      worker:
        function: actions/worker/index.js
        web: 'yes'
        runtime: 'nodejs:10'
        limits:
          concurrency: 42
        annotations:
          require-adobe-auth: true
```

Result snippet of `wsk action get $package-0.0.1/__secured_worker`:

```
    "limits": {
        "timeout": 60000,
        "memory": 256,
        "logs": 10,
        "concurrency": 42
    },
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
   - Note: there is no section in the Firefly documentation for supported manifest files yet
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
