### PR TITLE
fix web conductor actions for deploy manifest

### DIFF
--- a/src/runtime-helpers.js
+++ b/src/runtime-helpers.js
@@ -270,20 +270,23 @@ function returnDeploymentTriggerInputs (deploymentPackages) {
 }
 
 function returnAnnotations (action) {
-  let annotationParams = {}
+  const annotationParams = {}
+
+  // common annotations
 
   if (action['annotations'] && action['annotations']['conductor'] !== undefined) {
     annotationParams['conductor'] = action['annotations']['conductor']
   }
 
+  // web related annotations
+
   if (action['web'] !== undefined) {
-    annotationParams = checkWebFlags(action['web'])
+    Object.assign(annotationParams, checkWebFlags(action['web']))
   } else if (action['web-export'] !== undefined) {
-    annotationParams = checkWebFlags(action['web-export'])
+    Object.assign(annotationParams, checkWebFlags(action['web-export']))
   } else {
     annotationParams['web-export'] = false
     annotationParams['raw-http'] = false
-    return annotationParams
   }
 
   if (action['annotations'] && action['annotations']['require-whisk-auth'] !== undefined) {

--- a/test/__fixtures__/deploy/manifest_conductor.yaml
+++ b/test/__fixtures__/deploy/manifest_conductor.yaml
@@ -11,4 +11,8 @@ packages:
         function: /deploy/hello.js
         annotations:
             conductor: true
-            raw-http: true
+      anotherAction2:
+        function: /deploy/hello.js
+        web: 'yes'
+        annotations:
+            conductor: true

--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -399,6 +399,14 @@ describe('instance methods', () => {
             'web-export': false
           }
         })
+        expect(cmd).toHaveBeenCalledWith({
+          name: 'demo_package/anotherAction2',
+          action: hello,
+          annotations: {
+            conductor: true,
+            'web-export': true
+          }
+        })
         expect(stdout.output).toMatch('')
       })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
if the `web` action option is set then the conductor annotation is overwritten and ignored.
This is true even if `web: false|no`

From the openwhisk conductor spec: 

> Because a conductor action is an action, it has all the attributes of an action (name, namespace, default parameters, limits...) and it can be managed as such, for instance using the wsk action CLI commands. It can be part of a package or be a web action.

https://github.com/apache/openwhisk/blob/master/docs/conductors.md#conductor-annotation

This PR allows conductor actions to be web

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
