### PR TITLE
refactor tests to use useragent value from package.json version

### DIFF
--- a/test/commands/runtime/deploy/index.test.js
+++ b/test/commands/runtime/deploy/index.test.js
@@ -15,6 +15,8 @@ const TheCommand = require('../../../../src/commands/runtime/deploy/index.js')
 const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand.js')
 const RuntimeLib = require('@adobe/aio-lib-runtime')
 
+const pkgNameVersion = 'aio-cli-plugin-runtime@' + require('../../../../package.json').version
+
 const utils = RuntimeLib.utils
 
 test('exports', async () => {
@@ -78,7 +80,7 @@ describe('instance methods', () => {
     test('run with no params', async () => {
       command.argv = []
       await command.run()
-      expect(utils.setPaths).toHaveBeenCalledWith({ useragent: expect.any(String) })
+      expect(utils.setPaths).toHaveBeenCalledWith({ useragent: pkgNameVersion })
       expect(utils.getKeyValueObjectFromMergedParameters).toHaveBeenCalledWith(undefined, undefined)
 
       expect(utils.processPackage).toHaveBeenCalledWith(expectedPackages, expectedDepPackages, expectedDepTriggers, {}, false, expectedOWOptions)
@@ -93,7 +95,7 @@ describe('instance methods', () => {
       utils.getKeyValueObjectFromMergedParameters.mockReturnValue({ fake: 'params', fake2: 'params2' })
       await command.run()
 
-      expect(utils.setPaths).toHaveBeenCalledWith({ param: ['key', 'value'], useragent: expect.any(String) })
+      expect(utils.setPaths).toHaveBeenCalledWith({ param: ['key', 'value'], useragent: pkgNameVersion })
       expect(utils.getKeyValueObjectFromMergedParameters).toHaveBeenCalledWith(['key', 'value'], undefined)
 
       expect(utils.processPackage).toHaveBeenCalledWith(expectedPackages, expectedDepPackages, expectedDepTriggers, { fake: 'params', fake2: 'params2' }, false, expectedOWOptions)
@@ -108,7 +110,7 @@ describe('instance methods', () => {
       utils.getKeyValueObjectFromMergedParameters.mockReturnValue({ fake: 'params', fake2: 'params2' })
       await command.run()
 
-      expect(utils.setPaths).toHaveBeenCalledWith({ param: ['key', 'value', 'key2', 'value2'], useragent: expect.any(String) })
+      expect(utils.setPaths).toHaveBeenCalledWith({ param: ['key', 'value', 'key2', 'value2'], useragent: pkgNameVersion })
       expect(utils.getKeyValueObjectFromMergedParameters).toHaveBeenCalledWith(['key', 'value', 'key2', 'value2'], undefined)
 
       expect(utils.processPackage).toHaveBeenCalledWith(expectedPackages, expectedDepPackages, expectedDepTriggers, { fake: 'params', fake2: 'params2' }, false, expectedOWOptions)
@@ -123,7 +125,7 @@ describe('instance methods', () => {
       utils.getKeyValueObjectFromMergedParameters.mockReturnValue({ fake: 'params', fake2: 'params2' })
       await command.run()
 
-      expect(utils.setPaths).toHaveBeenCalledWith({ 'param-file': 'param-file.json', useragent: expect.any(String) })
+      expect(utils.setPaths).toHaveBeenCalledWith({ 'param-file': 'param-file.json', useragent: pkgNameVersion })
       expect(utils.getKeyValueObjectFromMergedParameters).toHaveBeenCalledWith(undefined, 'param-file.json')
 
       expect(utils.processPackage).toHaveBeenCalledWith(expectedPackages, expectedDepPackages, expectedDepTriggers, { fake: 'params', fake2: 'params2' }, false, expectedOWOptions)
@@ -138,7 +140,7 @@ describe('instance methods', () => {
       utils.getKeyValueObjectFromMergedParameters.mockReturnValue({ fake: 'params', fake2: 'params2' })
       await command.run()
 
-      expect(utils.setPaths).toHaveBeenCalledWith({ 'param-file': 'param-file.json', param: ['key', 'value', 'key2', 'value2'], useragent: expect.any(String) })
+      expect(utils.setPaths).toHaveBeenCalledWith({ 'param-file': 'param-file.json', param: ['key', 'value', 'key2', 'value2'], useragent: pkgNameVersion })
       expect(utils.getKeyValueObjectFromMergedParameters).toHaveBeenCalledWith(['key', 'value', 'key2', 'value2'], 'param-file.json')
 
       expect(utils.processPackage).toHaveBeenCalledWith(expectedPackages, expectedDepPackages, expectedDepTriggers, { fake: 'params', fake2: 'params2' }, false, expectedOWOptions)

--- a/test/commands/runtime/deploy/report.test.js
+++ b/test/commands/runtime/deploy/report.test.js
@@ -16,6 +16,8 @@ const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand.js')
 const RuntimeLib = require('@adobe/aio-lib-runtime')
 const utils = RuntimeLib.utils
 
+const pkgNameVersion = 'aio-cli-plugin-runtime@' + require('../../../../package.json').version
+
 test('exports', async () => {
   expect(typeof TheCommand).toEqual('function')
   expect(TheCommand.prototype instanceof RuntimeBaseCommand).toBeTruthy()
@@ -251,7 +253,7 @@ describe('instance methods', () => {
       })
 
       await command.run()
-      expect(utils.setPaths).toHaveBeenCalledWith({ manifest: 'fake-manifest.yaml', useragent: expect.any(String) })
+      expect(utils.setPaths).toHaveBeenCalledWith({ manifest: 'fake-manifest.yaml', useragent: pkgNameVersion })
       expect(utils.returnUnion).toHaveBeenCalledTimes(7)
       expect(utils.returnUnion).toHaveBeenCalledWith(fakePackages.pkg1.actions.two.inputs, {})
       expect(utils.returnUnion).toHaveBeenCalledWith(fakePackages.pkg2.triggers.triggerone.inputs, {})
@@ -276,7 +278,7 @@ describe('instance methods', () => {
         projectName: 'fakeProjectName'
       })
       await command.run()
-      expect(utils.setPaths).toHaveBeenCalledWith({ manifest: 'fake-manifest.yaml', deployment: 'fake-dep.yml', useragent: expect.any(String) })
+      expect(utils.setPaths).toHaveBeenCalledWith({ manifest: 'fake-manifest.yaml', deployment: 'fake-dep.yml', useragent: pkgNameVersion })
       expect(utils.returnUnion).toHaveBeenCalledTimes(7)
       expect(utils.returnUnion).toHaveBeenCalledWith(fakePackages.pkg1.actions.two.inputs, {})
       expect(utils.returnUnion).toHaveBeenCalledWith(fakePackages.pkg2.triggers.triggerone.inputs, fakeDepTriggers.triggerone)

--- a/test/commands/runtime/deploy/undeploy.test.js
+++ b/test/commands/runtime/deploy/undeploy.test.js
@@ -16,6 +16,8 @@ const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand.js')
 const RuntimeLib = require('@adobe/aio-lib-runtime')
 const utils = RuntimeLib.utils
 
+const pkgNameVersion = 'aio-cli-plugin-runtime@' + require('../../../../package.json').version
+
 test('exports', async () => {
   expect(typeof TheCommand).toEqual('function')
   expect(TheCommand.prototype instanceof RuntimeBaseCommand).toBeTruthy()
@@ -72,7 +74,7 @@ describe('instance methods', () => {
     test('run with no flags', async () => {
       command.argv = []
       await command.run()
-      expect(utils.setPaths).toHaveBeenCalledWith({ useragent: expect.any(String) })
+      expect(utils.setPaths).toHaveBeenCalledWith({ useragent: pkgNameVersion })
 
       expect(utils.processPackage).toHaveBeenCalledWith(expectedPackages, {}, {}, {}, true, expectedOWOptions)
       expect(utils.getProjectEntities).not.toHaveBeenCalled()
@@ -84,7 +86,7 @@ describe('instance methods', () => {
     test('run with manifest flag', async () => {
       command.argv = ['-m', 'fake-manifest.yml']
       await command.run()
-      expect(utils.setPaths).toHaveBeenCalledWith({ manifest: 'fake-manifest.yml', useragent: expect.any(String) })
+      expect(utils.setPaths).toHaveBeenCalledWith({ manifest: 'fake-manifest.yml', useragent: pkgNameVersion })
 
       expect(utils.processPackage).toHaveBeenCalledWith(expectedPackages, {}, {}, {}, true, expectedOWOptions)
       expect(utils.getProjectEntities).not.toHaveBeenCalled()


### PR DESCRIPTION
Tests for useragent values



## Motivation and Context

Previously tests were hardcoded with version numbers, which broke every release ...
Then this was changed to just test for a string, which is incomplete ...
This tests the value used for useragent is package name + package version


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
