### PR TITLE
Add typescript kind.

### DIFF
--- a/src/kinds.js
+++ b/src/kinds.js
@@ -32,6 +32,7 @@ function fileExtensionForKind (kind) {
       case 'ruby': return '.rb'
       case 'rust': return '.rs'
       case 'swift': return '.swift'
+      case 'typescript': return '.ts'
     }
   }
   return ''
@@ -57,6 +58,7 @@ function kindForFileExtension (filename) {
       case '.rb': return 'ruby:default'
       case '.rs': return 'rust:default'
       case '.swift': return 'swift:default'
+      case '.ts': return 'typescript:default'
     }
   }
   return undefined

--- a/test/kinds.test.js
+++ b/test/kinds.test.js
@@ -24,6 +24,7 @@ describe('fileExtensionForKind', () => {
     expect(kinds.fileExtensionForKind('ruby:abc')).toEqual('.rb')
     expect(kinds.fileExtensionForKind('rust:abc')).toEqual('.rs')
     expect(kinds.fileExtensionForKind('swift:abc')).toEqual('.swift')
+    expect(kinds.fileExtensionForKind('typescript:abc')).toEqual('.ts')
 
     // all kinds are colon separated but test defensively anyway
     expect(kinds.fileExtensionForKind('swift')).toEqual('.swift')
@@ -48,6 +49,7 @@ describe('kindForFileExtension', () => {
     expect(kinds.kindForFileExtension('f.rb')).toEqual('ruby:default')
     expect(kinds.kindForFileExtension('f.rs')).toEqual('rust:default')
     expect(kinds.kindForFileExtension('f.swift')).toEqual('swift:default')
+    expect(kinds.kindForFileExtension('f.ts')).toEqual('typescript:default')
 
     expect(kinds.kindForFileExtension(undefined)).toEqual(undefined)
     expect(kinds.kindForFileExtension('')).toEqual(undefined)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This add file/runtime kind recognition for Typescript. While AIO may not support it, it permits the CLI to be used with other deployments. The API server should reject any runtime that is not supported by the deployment.

<!--- Describe your changes in detail -->

## Related Issue
Closes #211.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
