### PR TITLE
Add flag to show action code.

### DIFF
--- a/src/commands/runtime/action/get.js
+++ b/src/commands/runtime/action/get.js
@@ -61,6 +61,14 @@ class ActionGet extends RuntimeBaseCommand {
             const saveFileName = bSaveFile ? flags['save-as'] : `${result.name}${extension}`
             fs.writeFileSync(saveFileName, result.exec.code)
           }
+        } else if (ActionGet.fullGet) {
+          this.logJSON('', result)
+        } else if (flags.code) {
+          if (!result.exec.binary) {
+            this.log(result.exec.code)
+          } else {
+            throw new Error(ActionGet.codeNotText)
+          }
         } else {
           // destructure getAction to remove the exec.code
           this.logJSON(`${result.name}\n`, { ...result,
@@ -71,7 +79,11 @@ class ActionGet extends RuntimeBaseCommand {
         }
       }
     } catch (err) {
-      this.handleError('failed to retrieve the action', err)
+      if (err.message === ActionGet.codeNotText) {
+        this.handleError(err.message)
+      } else {
+        this.handleError('failed to retrieve the action', err)
+      }
     }
   }
 }
@@ -89,6 +101,10 @@ ActionGet.flags = {
     char: 'r',
     description: 'get action url'
   }),
+  code: flags.boolean({
+    char: 'c',
+    description: 'show action code (only works if code is not a zip file)'
+  }),
   save: flags.boolean({
     description: 'save action code to file corresponding with action name'
   }),
@@ -96,6 +112,12 @@ ActionGet.flags = {
     description: 'file to save action code to'
   })
 }
+
+// global toggle to allow clients to retrieve the action code
+// and metadata at once
+ActionGet.fullGet = false
+
+ActionGet.codeNotText = 'Cannot display code because it is not plaintext.'
 
 ActionGet.description = 'Retrieves an Action'
 

--- a/test/__fixtures__/action/get.json
+++ b/test/__fixtures__/action/get.json
@@ -16,7 +16,7 @@
   "exec": {
     "binary": false,
     "kind": "nodejs:10-fat",
-    "code":"this is the code"
+    "code": "this is the code"
   },
   "limits": {
     "concurrency": 1,

--- a/test/commands/runtime/action/get.test.js
+++ b/test/commands/runtime/action/get.test.js
@@ -257,5 +257,42 @@ describe('instance methods', () => {
             bufferData, 'buffer')
         })
     })
+
+    test('retrieve an action and do not omit code', () => {
+      TheCommand.fullGet = true
+      const cmd = rtLib.mockResolvedFixture(rtAction, 'action/get.json')
+      command.argv = ['hello']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith('hello')
+          const result = JSON.parse(stdout.output)
+          delete result.date
+          expect(`${JSON.stringify(result, null, 2)}\n`).toMatchFixture('action/get.json')
+        })
+        .finally(() => { TheCommand.fullGet = false })
+    })
+
+    test('show action code --code', () => {
+      const cmd = rtLib.mockResolvedFixture(rtAction, 'action/get.json')
+      command.argv = ['hello', '--code']
+      return command.run()
+        .then(() => {
+          expect(cmd).toHaveBeenCalledWith('hello')
+          expect(stdout.output).toMatch('this is the code')
+        })
+    })
+
+    test('report error for show binary action code --code', () => {
+      return new Promise((resolve, reject) => {
+        rtLib.mockResolvedFixture(rtAction, 'action/get.binary.json')
+        command.argv = ['hello', '--code']
+        return command.run()
+          .then(() => reject(new Error('does not throw error')))
+          .catch(() => {
+            expect(handleError).toHaveBeenLastCalledWith(TheCommand.codeNotText)
+            resolve()
+          })
+      })
+    })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using action get, add a flag `--code` (`-c`) to show the action's code, when the code is in text form.
Additionally, add a global flag that allows action get to show the full action document as JSON when desirable.

## Related Issue

Closes #212.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
