### PR TITLE
docs: updated usage installation instructions in README.md (issue #226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Adobe I/O Runtime plugin for the Adobe I/O CLI
 
 # Usage
 ```sh-session
-$ aio plugins:install -g @adobe/aio-cli-plugin-runtime
+$ aio plugins:install @adobe/aio-cli-plugin-runtime
 $ # OR
 $ aio discover -i
 $ aio runtime --help


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updating the installation instructions in the Usage sections of the README to remove -g from the install command as below.  

```diff
-aio plugins:install -g @adobe/aio-cli-plugin-runtime
+aio plugins:install @adobe/aio-cli-plugin-runtime
```

## Related Issue

https://github.com/adobe/aio-cli-plugin-runtime/issues/226

## Motivation and Context
Updates readme installation instructions as using ```aio plugins:install -g @adobe/aio-cli-plugin-runtime``` causes an error.  

## How Has This Been Tested?
The update I have made only affects the readme but I ran the unit tests and test/commands/runtime/activation/list.test.js fails which appears to be due to slight difference in received string.  This should not relate to the change I have made in the readme.  

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

The following test fails which appears to be due to slight difference in string received compared to expected substring.  
 ```
FAIL  test/commands/runtime/activation/list.test.js (11.088s)
  ● instance methods › run › return list of trigger activations
```
