### PR TITLE
[ACNA-1106] Omit old logs while continuous logs fetching

### DIFF
--- a/src/commands/runtime/activation/logs.js
+++ b/src/commands/runtime/activation/logs.js
@@ -63,8 +63,10 @@ class ActivationLogs extends RuntimeBaseCommand {
       } else if (flags.action) {
         filterActions.push(flags.action)
       }
+      const tail = flags.poll || flags.tail || flags.watch
+      const startTime = tail ? Date.now() : 0
 
-      await rtLib.printActionLogs({ ow: owOptions }, this.log, limit, filterActions, flags.strip, flags.poll || flags.tail || flags.watch)
+      await rtLib.printActionLogs({ ow: owOptions }, this.log, limit, filterActions, flags.strip, tail, undefined, startTime)
     } else {
       const logger = this.log
       return ow.activations.logs(args.activationId).then((result) => {

--- a/test/commands/runtime/activation/logs.test.js
+++ b/test/commands/runtime/activation/logs.test.js
@@ -109,7 +109,7 @@ describe('instance methods', () => {
       command.argv = []
       return command.run()
         .then(() => {
-          expect(RuntimeLib.printActionLogs).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything())
+          expect(RuntimeLib.printActionLogs).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything(), undefined, expect.anything())
         })
     })
 
@@ -117,7 +117,7 @@ describe('instance methods', () => {
       command.argv = ['-l']
       return command.run()
         .then(() => {
-          expect(RuntimeLib.printActionLogs).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything())
+          expect(RuntimeLib.printActionLogs).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything(), undefined, expect.anything())
         })
     })
 
@@ -125,7 +125,7 @@ describe('instance methods', () => {
       command.argv = ['-l']
       return command.run()
         .then(() => {
-          expect(RuntimeLib.printActionLogs).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything())
+          expect(RuntimeLib.printActionLogs).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything(), undefined, expect.anything())
           expect(stdout.output).toMatch('')
         })
     })
@@ -134,7 +134,7 @@ describe('instance methods', () => {
       command.argv = ['--last']
       return command.run()
         .then(() => {
-          expect(RuntimeLib.printActionLogs).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything())
+          expect(RuntimeLib.printActionLogs).toHaveBeenCalledWith(expect.anything(), expect.anything(), 1, expect.anything(), expect.anything(), expect.anything(), undefined, expect.anything())
         })
     })
 
@@ -142,7 +142,7 @@ describe('instance methods', () => {
       command.argv = ['--limit', '2']
       return command.run()
         .then(() => {
-          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 2, expect.anything(), expect.anything(), expect.anything())
+          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 2, expect.anything(), expect.anything(), expect.anything(), undefined, expect.anything())
         })
     })
 
@@ -166,7 +166,7 @@ describe('instance methods', () => {
       command.argv = ['-m']
       return command.run()
         .then(() => {
-          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, ['pkg1/hello', 'pkg2/hello2'], expect.anything(), expect.anything())
+          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, ['pkg1/hello', 'pkg2/hello2'], expect.anything(), expect.anything(), undefined, expect.anything())
         })
     })
 
@@ -190,7 +190,7 @@ describe('instance methods', () => {
       command.argv = ['-p', 'pkg1']
       return command.run()
         .then(() => {
-          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, ['pkg1/hello'], expect.anything(), expect.anything())
+          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, ['pkg1/hello'], expect.anything(), expect.anything(), undefined, expect.anything())
         })
     })
 
@@ -238,7 +238,7 @@ describe('instance methods', () => {
       command.argv = ['-p', 'pkg1', '--deployed']
       return command.run()
         .then(() => {
-          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, ['pkg1/'], expect.anything(), expect.anything())
+          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, ['pkg1/'], expect.anything(), expect.anything(), undefined, expect.anything())
         })
     })
 
@@ -262,7 +262,16 @@ describe('instance methods', () => {
       command.argv = ['-a', 'hello']
       return command.run()
         .then(() => {
-          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, ['hello'], expect.anything(), expect.anything())
+          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, ['hello'], expect.anything(), expect.anything(), undefined, expect.anything())
+        })
+    })
+    test('startTime is now when fetching continuously', () => {
+      const mockedNow = 1487076708000
+      Date.now = jest.fn(() => mockedNow)
+      command.argv = ['-t']
+      return command.run()
+        .then(() => {
+          expect(RuntimeLib.printActionLogs).toHaveBeenLastCalledWith(expect.anything(), expect.anything(), 1, [], expect.anything(), expect.anything(), undefined, 1487076708000)
         })
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #225
https://github.com/adobe/aio-cli-plugin-app/issues/277

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
`startTime` is being used to filter out the logs to be printed. 
While `--tail` or any other continuously fetching param, it should only fetch logs since Date.now().

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Steps: 
1. cd into the generated firefly project. 
2. run `aio runtime activation logs --tail`.
3. While `aio runtime activation logs --tail` is running, generate some logs via the firefly app.
Expected: Only logs following the `aio runtime activation logs --tail` should be printed.  

Steps: 
1. cd firefly project.
2. run `aio runtime activation logs`
Expected: Logs prior to `aio runtime activation logs` should be printed. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
