### PR TITLE
feat. Recursive delete of a package

### DIFF
--- a/src/commands/runtime/trigger/list.js
+++ b/src/commands/runtime/trigger/list.js
@@ -98,7 +98,8 @@ TriggerList.flags = {
   ...RuntimeBaseCommand.flags,
   limit: flags.integer({
     char: 'l',
-    description: 'only return LIMIT number of triggers'
+    description: 'only return LIMIT number of triggers',
+    default: 30
   }),
   skip: flags.integer({
     char: 's',

--- a/test/commands/runtime/package/delete.test.js
+++ b/test/commands/runtime/package/delete.test.js
@@ -36,7 +36,7 @@ test('args', async () => {
   const deleteName = TheCommand.args[0]
   expect(deleteName.name).toBeDefined()
   expect(deleteName.name).toEqual('packageName')
-  expect(deleteName.required).toEqual(false)
+  expect(deleteName.required).toEqual(true)
 })
 
 describe('instance methods', () => {
@@ -73,22 +73,41 @@ describe('instance methods', () => {
       const mockPackageList = [
         { namespace: 'namespace', name: 'package1' }
       ]
+      const mockRulesList = [{
+        name: 'rule1',
+        action: {
+          name: 'action1'
+        },
+        trigger: {
+          name: 'trigger1',
+          path: 'triggerPath'
+        }
+      }]
+      rtUtils.parsePackageName.mockReturnValue({ name: 'package1', namespace: 'namespace' })
       const deleteAction = rtLib.mockResolved('actions.delete', 'Deleted Item')
       const deletePackage = rtLib.mockResolved('packages.delete', 'Deleted Item')
+      const deleteRule = rtLib.mockResolved('rules.delete', 'Deleted Item')
+      const deleteTrigger = rtLib.mockResolved('triggers.delete', 'Deleted Item')
+
       rtLib.mockResolved('actions.list', mockActionList)
       rtLib.mockResolved('packages.list', mockPackageList)
+      rtLib.mockResolved('rules.list', mockRulesList)
 
-      command.argv = ['--recursive']
+      command.argv = ['packageName', '--recursive']
       return command.run()
         .then(() => {
           expect(deleteAction).toHaveBeenCalledWith(mockActionList[0])
-          expect(deletePackage).toHaveBeenCalledWith([mockPackageList[0]])
-          expect(rtUtils.parsePackageName).not.toHaveBeenCalled()
+          expect(deletePackage).toHaveBeenCalledWith(mockPackageList[0])
+          expect(deleteRule).toHaveBeenCalledWith(mockRulesList[0].name)
+          expect(deleteTrigger).toHaveBeenCalledWith({
+            triggerName: mockRulesList[0].trigger.name,
+            namespace: mockRulesList[0].trigger.path
+          })
           expect(stdout.output).toMatch('')
         })
     })
 
-    test('delete packages, --recursive, skip deleting actions (else coverage)', () => {
+    test('delete package, --recursive, no actions', () => {
       const mockActionList = [
         { name: 'action1', namespace: 'namespace/somepackage' },
         { name: 'action2', namespace: 'namespace2/notmypackage' }
@@ -96,32 +115,49 @@ describe('instance methods', () => {
       const mockPackageList = [
         { namespace: 'namespace', name: 'package1' }
       ]
+      rtUtils.parsePackageName.mockReturnValue({ name: 'package1', namespace: 'namespace' })
       const deleteAction = rtLib.mockResolved('actions.delete', 'Deleted Item')
       const deletePackage = rtLib.mockResolved('packages.delete', 'Deleted Item')
       rtLib.mockResolved('actions.list', mockActionList)
       rtLib.mockResolved('packages.list', mockPackageList)
 
-      command.argv = ['--recursive']
+      command.argv = ['packageName', '--recursive']
       return command.run()
         .then(() => {
           expect(deleteAction).not.toHaveBeenCalled()
-          expect(deletePackage).toHaveBeenCalledWith([mockPackageList[0]])
-          expect(rtUtils.parsePackageName).not.toHaveBeenCalled()
+          expect(deletePackage).toHaveBeenCalledWith(mockPackageList[0])
           expect(stdout.output).toMatch('')
         })
     })
 
-    test('custom error message, no packageName provided', () => {
-      return new Promise((resolve, reject) => {
-        rtLib.mockRejected(rtAction, new Error('an error'))
-        command.argv = ['']
-        return command.run()
-          .then(() => reject(new Error('does not throw error')))
-          .catch(() => {
-            expect(handleError).toHaveBeenLastCalledWith('failed to delete the package', new Error('Missing 1 required arg: packageName'))
-            resolve()
-          })
-      })
+    test('delete package, --recursive, no rules', () => {
+      const mockActionList = [
+        { name: 'action1', namespace: 'namespace/package1' },
+        { name: 'action2', namespace: 'namespace2' }
+      ]
+      const mockPackageList = [
+        { namespace: 'namespace', name: 'package1' }
+      ]
+      const mockRulesList = null
+      rtUtils.parsePackageName.mockReturnValue({ name: 'package1', namespace: 'namespace' })
+      const deleteAction = rtLib.mockResolved('actions.delete', 'Deleted Item')
+      const deletePackage = rtLib.mockResolved('packages.delete', 'Deleted Item')
+      const deleteRule = rtLib.mockResolved('rules.delete', 'Deleted Item')
+      const deleteTrigger = rtLib.mockResolved('triggers.delete', 'Deleted Item')
+
+      rtLib.mockResolved('actions.list', mockActionList)
+      rtLib.mockResolved('packages.list', mockPackageList)
+      rtLib.mockResolved('rules.list', mockRulesList)
+
+      command.argv = ['packageName', '--recursive']
+      return command.run()
+        .then(() => {
+          expect(deleteAction).toHaveBeenCalledWith(mockActionList[0])
+          expect(deletePackage).toHaveBeenCalledWith(mockPackageList[0])
+          expect(deleteRule).not.toHaveBeenCalled()
+          expect(deleteTrigger).not.toHaveBeenCalled()
+          expect(stdout.output).toMatch('')
+        })
     })
 
     test('delete a package /ns', () => {

--- a/test/commands/runtime/trigger/list.test.js
+++ b/test/commands/runtime/trigger/list.test.js
@@ -122,7 +122,7 @@ describe('instance methods', () => {
       command.argv = ['--skip', '5']
       return command.run()
         .then(() => {
-          expect(cmd).toHaveBeenCalledWith({ skip: 5 })
+          expect(cmd).toHaveBeenCalledWith({ skip: 5, limit: 30 })
           expect(stdout.output).toMatch('')
         })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added support for non-empty packages deletion. 

## Description
Usage: 
`aio runtime package delete packageName --recursive`.
Will delete the package named `packageName`, will delete actions, rules & triggers associated with the actions.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/adobe/aio-cli-plugin-runtime/issues/159

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?
unit tests.
Steps: 
- use a manifest to configure a package with an action. 
- configure the package to include a rule and link the action + the trigger.
- inside an `aio` project, execute: 
         `aio runtime package list` to retrieve a list of the packages. Identify the package you just deployed. 
         `aio runtime package delete packageName` should return an error.
- `aio runtime package delete packageName --recursive` should delete the package and the action & rule & trigger configured. 
        

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
