### PR TITLE
feat: use oclif min / max for activation list limit flag

### DIFF
--- a/src/commands/runtime/activation/list.js
+++ b/src/commands/runtime/activation/list.js
@@ -205,7 +205,7 @@ ActivationList.args = [
 ]
 
 ActivationList.limits = {
-  max: 200
+  max: 50
 }
 
 ActivationList.flags = {
@@ -213,7 +213,9 @@ ActivationList.flags = {
   // example usage:  aio runtime:activation:list --limit 10 --skip 2
   limit: Flags.integer({
     char: 'l',
-    description: 'only return LIMIT number of activations'
+    description: `only return LIMIT number of activations (Max: ${ActivationList.limits.max})`,
+    min: 0,
+    max: ActivationList.limits.max
   }),
   skip: Flags.integer({
     char: 's',


### PR DESCRIPTION
Was testing `activation list --limit=x` for a customer issue in the app-builder channel and realized it was not only spitting out an ugly error, but also actually making the network call if you tried using too large or too small of a value. 

**Before**

```
➜  the-worst-folder git:(main) aio rt activations list --limit=51
 ›   Error: failed to list the activations: the query parameter 'limit' was malformed:
 ›   the value '51' is not in the range of 0 to 50 for activations. (400 Bad Request)
 ›    specify --verbose flag for more information
```

**After**

(Pending oclif/core PR [here](https://github.com/oclif/core/pull/589))

```
➜  the-best-folder git:(main) aio rt activations list --limit=51
    Error: Parsing --limit 
        Expected an integer less than or equal to 50 but received: 51
    See more help with --help
```