### PR TITLE
feat: use oclif min and max for all numeric flags

### DIFF
--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -230,6 +230,21 @@ ActionCreate.args = [
   }
 ]
 
+ActionCreate.limits = {
+  timeoutMs: {
+    min: 100,
+    max: 3600000
+  },
+  memoryMB: {
+    min: 128,
+    max: 4096
+  },
+  logsizeMB: {
+    min: 0,
+    max: 10
+  }
+}
+
 ActionCreate.flags = {
   ...RuntimeBaseCommand.flags,
   param: Flags.string({
@@ -263,15 +278,21 @@ ActionCreate.flags = {
   }),
   timeout: Flags.integer({
     char: 't',
-    description: 'the timeout LIMIT in milliseconds after which the action is terminated (default 60000)' // help description for flag
+    description: `the timeout LIMIT in milliseconds after which the action is terminated (default 60000, min: ${ActionCreate.limits.timeoutMs.min}, max: ${ActionCreate.limits.timeoutMs.max})`, // help description for flag
+    min: ActionCreate.limits.timeoutMs.min,
+    max: ActionCreate.limits.timeoutMs.max
   }),
   memory: Flags.integer({
     char: 'm',
-    description: 'the maximum memory LIMIT in MB for the action (default 256)' // help description for flag
+    description: `the maximum memory LIMIT in MB for the action (default 256, min: ${ActionCreate.limits.memoryMB.min}, max: ${ActionCreate.limits.memoryMB.max})`, // help description for flag
+    min: ActionCreate.limits.memoryMB.min,
+    max: ActionCreate.limits.memoryMB.max
   }),
   logsize: Flags.integer({
     char: 'l',
-    description: 'the maximum log size LIMIT in MB for the action (default 10)' // help description for flag
+    description: `the maximum log size LIMIT in MB for the action (default 10, min: ${ActionCreate.limits.logsizeMB.min}, max: ${ActionCreate.limits.logsizeMB.max})`, // help description for flag
+    min: ActionCreate.limits.logsizeMB.min,
+    max: ActionCreate.limits.logsizeMB.max
   }),
   kind: Flags.string({
     description: 'the KIND of the action runtime (example: swift:default, nodejs:default)' // help description for flag

--- a/src/commands/runtime/action/list.js
+++ b/src/commands/runtime/action/list.js
@@ -101,12 +101,19 @@ ActionList.args = [
   }
 ]
 
+ActionList.limits = {
+  min: 0,
+  max: 50
+}
+
 ActionList.flags = {
   ...RuntimeBaseCommand.flags,
   // example usage:  aio runtime:action:list --limit 10 --skip 2
   limit: Flags.integer({
     char: 'l',
-    description: 'only return LIMIT number of actions'
+    description: `only return LIMIT number of actions (min: ${ActionList.limits.min} max: ${ActionList.limits.max})`,
+    min: ActionList.limits.min,
+    max: ActionList.limits.max
   }),
   skip: Flags.integer({
     char: 's',

--- a/src/commands/runtime/action/list.js
+++ b/src/commands/runtime/action/list.js
@@ -111,7 +111,7 @@ ActionList.flags = {
   // example usage:  aio runtime:action:list --limit 10 --skip 2
   limit: Flags.integer({
     char: 'l',
-    description: `only return LIMIT number of actions (min: ${ActionList.limits.min} max: ${ActionList.limits.max})`,
+    description: `only return LIMIT number of actions (min: ${ActionList.limits.min}, max: ${ActionList.limits.max})`,
     min: ActionList.limits.min,
     max: ActionList.limits.max
   }),

--- a/src/commands/runtime/activation/list.js
+++ b/src/commands/runtime/activation/list.js
@@ -205,6 +205,7 @@ ActivationList.args = [
 ]
 
 ActivationList.limits = {
+  min: 0,
   max: 50
 }
 
@@ -213,8 +214,8 @@ ActivationList.flags = {
   // example usage:  aio runtime:activation:list --limit 10 --skip 2
   limit: Flags.integer({
     char: 'l',
-    description: `only return LIMIT number of activations (Max: ${ActivationList.limits.max})`,
-    min: 0,
+    description: `only return LIMIT number of activations (min: ${ActivationList.limits.min}, max: ${ActivationList.limits.max})`,
+    min: ActivationList.limits.min,
     max: ActivationList.limits.max
   }),
   skip: Flags.integer({

--- a/src/commands/runtime/activation/logs.js
+++ b/src/commands/runtime/activation/logs.js
@@ -92,6 +92,11 @@ ActivationLogs.args = [
   }
 ]
 
+ActivationLogs.limits = {
+  min: 0,
+  max: 50
+}
+
 ActivationLogs.flags = {
   ...RuntimeBaseCommand.flags,
   action: Flags.string({
@@ -124,8 +129,10 @@ ActivationLogs.flags = {
     default: false
   }),
   limit: Flags.integer({
-    description: 'return logs only from last LIMIT number of activations',
-    exclusive: ['last']
+    description: `return logs only from last LIMIT number of activations (min: ${ActivationLogs.limits.min}, max: ${ActivationLogs.limits.max})`,
+    exclusive: ['last'],
+    min: ActivationLogs.limits.min,
+    max: ActivationLogs.limits.max
   }),
   tail: Flags.boolean({
     description: 'Fetch logs continuously',

--- a/src/commands/runtime/package/list.js
+++ b/src/commands/runtime/package/list.js
@@ -86,13 +86,20 @@ class PackageList extends RuntimeBaseCommand {
   }
 }
 
+PackageList.limits = {
+  min: 0,
+  max: 50
+}
+
 PackageList.flags = {
   ...RuntimeBaseCommand.flags,
   // example usage:  aio runtime:package:list --limit 10 --skip 2
   // aio runtime:package:list --count true OR  aio runtime:package:list --count yes
   limit: Flags.integer({
     char: 'l',
-    description: 'only return LIMIT number of packages'
+    description: `only return LIMIT number of packages (min: ${PackageList.limits.min}, max: ${PackageList.limits.max})`,
+    min: PackageList.limits.min,
+    max: PackageList.limits.max
   }),
   skip: Flags.integer({
     char: 's',

--- a/src/commands/runtime/rule/list.js
+++ b/src/commands/runtime/rule/list.js
@@ -80,11 +80,18 @@ class RuleList extends RuntimeBaseCommand {
 
 RuleList.description = 'Retrieves a list of Rules'
 
+RuleList.limits = {
+  min: 0,
+  max: 50
+}
+
 RuleList.flags = {
   ...RuntimeBaseCommand.flags,
   limit: Flags.integer({
     char: 'l',
-    description: 'Limit number of rules returned'
+    description: `Limit number of rules returned (min: ${RuleList.limits.min}, max: ${RuleList.limits.max})`,
+    min: RuleList.limits.min,
+    max: RuleList.limits.max
   }),
   skip: Flags.integer({
     char: 's',

--- a/src/commands/runtime/trigger/list.js
+++ b/src/commands/runtime/trigger/list.js
@@ -93,11 +93,18 @@ class TriggerList extends RuntimeBaseCommand {
   }
 }
 
+TriggerList.limits = {
+  min: 0,
+  max: 50
+}
+
 TriggerList.flags = {
   ...RuntimeBaseCommand.flags,
   limit: Flags.integer({
     char: 'l',
-    description: 'only return LIMIT number of triggers',
+    description: `only return LIMIT number of triggers (min: ${TriggerList.limits.min}, max: ${TriggerList.limits.max})`,
+    min: TriggerList.limits.min,
+    max: TriggerList.limits.max,
     default: 30
   }),
   skip: Flags.integer({

--- a/test/commands/runtime/action/create.test.js
+++ b/test/commands/runtime/action/create.test.js
@@ -806,6 +806,48 @@ describe('instance methods', () => {
       await expect(rejectWithError(command, error, handleError)).toBeTruthy()
     })
 
+    test('errors out on create with timeout below min', async () => {
+      const flag = '--timeout'
+      const invalidValue = '99'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 100 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on create with timeout above max', async () => {
+      const flag = '--timeout'
+      const invalidValue = '3600001'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 3600000 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on create with memory below min', async () => {
+      const flag = '--memory'
+      const invalidValue = '127'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 128 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on create with memory above max', async () => {
+      const flag = '--memory'
+      const invalidValue = '4097'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 4096 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on create with logsize below min', async () => {
+      const flag = '--logsize'
+      const invalidValue = '-1'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on create with logsize above max', async () => {
+      const flag = '--logsize'
+      const invalidValue = '11'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 10 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
     test('errors on --web-secure with --web false flag', async () => {
       rtLib.mockRejected(rtAction, '')
       command.argv = ['hello', '/action/fileWithNoExt', '--web-secure', 'true', '--web', 'false']

--- a/test/commands/runtime/action/list.test.js
+++ b/test/commands/runtime/action/list.test.js
@@ -165,6 +165,20 @@ describe('instance methods', () => {
       expect(handleError).toHaveBeenLastCalledWith('failed to list the actions', new Error('an error'))
     })
 
+    test('errors out on list with limit below min', async () => {
+      const flag = '--limit'
+      const invalidValue = '-1'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on list with limit above max', async () => {
+      const flag = '--limit'
+      const invalidValue = '51'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
     test('return list of actions with annotated kinds', () => {
       const data = [
         {

--- a/test/commands/runtime/activation/list.test.js
+++ b/test/commands/runtime/activation/list.test.js
@@ -390,6 +390,20 @@ describe('instance methods', () => {
       expect(handleError).toHaveBeenLastCalledWith('failed to list the activations', new Error('an error'))
     })
 
+    test('errors out on list with limit below min', async () => {
+      const flag = '--limit'
+      const invalidValue = '-1'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on list with limit above max', async () => {
+      const flag = '--limit'
+      const invalidValue = '51'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
     test('ignore activation without annotations', () => {
       const data = [
         {

--- a/test/commands/runtime/activation/logs.test.js
+++ b/test/commands/runtime/activation/logs.test.js
@@ -109,6 +109,20 @@ describe('instance methods', () => {
       expect(handleError).toHaveBeenCalledWith('failed to retrieve logs for activation', expect.any(Error))
     })
 
+    test('errors out on list with limit below min', async () => {
+      const flag = '--limit'
+      const invalidValue = '-1'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on list with limit above max', async () => {
+      const flag = '--limit'
+      const invalidValue = '51'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
     test('retrieve last log (default)', () => {
       command.argv = []
       return command.run()

--- a/test/commands/runtime/package/list.test.js
+++ b/test/commands/runtime/package/list.test.js
@@ -168,5 +168,19 @@ describe('instance methods', () => {
           expect(JSON.parse(stdout.output)).toEqual({ packages: 2 })
         })
     })
+
+    test('errors out on list with limit below min', async () => {
+      const flag = '--limit'
+      const invalidValue = '-1'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on list with limit above max', async () => {
+      const flag = '--limit'
+      const invalidValue = '51'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
+    })
   })
 })

--- a/test/commands/runtime/rule/list.test.js
+++ b/test/commands/runtime/rule/list.test.js
@@ -213,5 +213,19 @@ describe('instance methods', () => {
       await expect(command.run()).rejects.toThrow(...error)
       expect(handleError).toHaveBeenLastCalledWith(...error)
     })
+
+    test('errors out on list with limit below min', async () => {
+      const flag = '--limit'
+      const invalidValue = '-1'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on list with limit above max', async () => {
+      const flag = '--limit'
+      const invalidValue = '51'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
+    })
   })
 })

--- a/test/commands/runtime/trigger/list.test.js
+++ b/test/commands/runtime/trigger/list.test.js
@@ -211,6 +211,20 @@ describe('instance methods', () => {
       expect(handleError).toHaveBeenLastCalledWith(...error)
     })
 
+    test('errors out on list with limit below min', async () => {
+      const flag = '--limit'
+      const invalidValue = '-1'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on list with limit above max', async () => {
+      const flag = '--limit'
+      const invalidValue = '51'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
     test('return list of triggers, --name-sort flag', () => {
       const cmd = rtLib.mockResolvedFixture(rtAction, 'trigger/list-name-sort.json')
       command.argv = ['--name']


### PR DESCRIPTION
Continuation of https://github.com/adobe/aio-cli-plugin-runtime/pull/270

Figured we should do this for all numeric flags and then cut a release

## Related Issue

Closes https://github.com/adobe/aio-cli-plugin-runtime/issues/273

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Locally linked plugin, `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
