### PR TITLE
CEXT-2009 Add New Relic support to aio CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ $ aio runtime --help
 * [`aio runtime namespace log-forwarding set adobe-io-runtime`](#aio-runtime-namespace-log-forwarding-set-adobe-io-runtime)
 * [`aio runtime namespace log-forwarding set azure-log-analytics`](#aio-runtime-namespace-log-forwarding-set-azure-log-analytics)
 * [`aio runtime namespace log-forwarding set splunk-hec`](#aio-runtime-namespace-log-forwarding-set-splunk-hec)
+* [`aio runtime namespace log-forwarding set new-relic`](#aio-runtime-namespace-log-forwarding-set-new-relic)
 * [`aio runtime package`](#aio-runtime-package)
 * [`aio runtime package bind PACKAGENAME BINDPACKAGENAME`](#aio-runtime-package-bind-packagename-bindpackagename)
 * [`aio runtime package create PACKAGENAME`](#aio-runtime-package-create-packagename)
@@ -1280,6 +1281,42 @@ ALIASES
   $ aio rt namespace lf set splunk-hec
   $ aio rt ns log-forwarding set splunk-hec
   $ aio rt ns lf set splunk-hec
+```
+
+## `aio runtime namespace log-forwarding set new-relic`
+
+Set log forwarding destination to New Relic
+
+```
+USAGE
+  $ aio runtime namespace log-forwarding set new-relic --base-uri <value> --license-key <value>  [--cert] [--key]
+    [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version] [--help]
+
+FLAGS
+  -i, --insecure         bypass certificate check
+  -u, --auth             whisk auth
+  -v, --verbose          Verbose output
+  --apihost              whisk API host
+  --apiversion           whisk API version
+  --base-uri=<value>     (optional) Base URI
+  --cert                 client cert
+  --debug=<value>        Debug level output
+  --help                 Show help
+  --key                  client key
+  --license-key=<value>  (required) License key
+  --version              Show version
+
+DESCRIPTION
+  Set log forwarding destination to New Relic
+
+ALIASES
+  $ aio runtime ns log-forwarding set new-relic
+  $ aio runtime ns lf set new-relic
+  $ aio runtime namespace lf set new-relic
+  $ aio rt namespace log-forwarding set new-relic
+  $ aio rt namespace lf set new-relic
+  $ aio rt ns log-forwarding set new-relic
+  $ aio rt ns lf set new-relic
 ```
 
 ## `aio runtime package`

--- a/src/commands/runtime/namespace/log-forwarding/set/new-relic.js
+++ b/src/commands/runtime/namespace/log-forwarding/set/new-relic.js
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Flags } = require('@oclif/core')
+const RuntimeBaseCommand = require('../../../../../RuntimeBaseCommand')
+
+class NewRelicCommand extends RuntimeBaseCommand {
+  async run () {
+    const { flags } = await this.parse(NewRelicCommand)
+    const ow = await this.wsk()
+    try {
+      await ow.logForwarding.setDestination('new_relic', {
+        base_uri: flags['base-uri'],
+        license_key: flags['license-key']
+      })
+      this.log('Log forwarding was set to new_relic for this namespace')
+    } catch (e) {
+      await this.handleError('failed to update log forwarding configuration', e)
+    }
+  }
+}
+
+NewRelicCommand.description = 'Set log forwarding destination to New Relic'
+
+NewRelicCommand.flags = {
+  ...RuntimeBaseCommand.flags,
+  'base-uri': Flags.string({
+    description: 'Base URI',
+    required: false
+  }),
+  'license-key': Flags.string({
+    description: 'License Key',
+    required: true
+  })
+}
+
+NewRelicCommand.aliases = [
+  'runtime:ns:log-forwarding:set:new-relic',
+  'runtime:ns:lf:set:new-relic',
+  'runtime:namespace:lf:set:new-relic',
+  'rt:namespace:log-forwarding:set:new-relic',
+  'rt:namespace:lf:set:new-relic',
+  'rt:ns:log-forwarding:set:new-relic',
+  'rt:ns:lf:set:new-relic'
+]
+
+module.exports = NewRelicCommand

--- a/src/commands/runtime/namespace/log-forwarding/set/new-relic.js
+++ b/src/commands/runtime/namespace/log-forwarding/set/new-relic.js
@@ -35,7 +35,7 @@ NewRelicCommand.flags = {
   ...RuntimeBaseCommand.flags,
   'base-uri': Flags.string({
     description: 'Base URI',
-    required: false
+    required: true
   }),
   'license-key': Flags.string({
     description: 'License Key',

--- a/test/__mocks__/@adobe/aio-lib-runtime.js
+++ b/test/__mocks__/@adobe/aio-lib-runtime.js
@@ -16,7 +16,8 @@ const mockRtLibInstance = {
     get: jest.fn(),
     setAdobeIoRuntime: jest.fn(),
     setAzureLogAnalytics: jest.fn(),
-    setSplunkHec: jest.fn()
+    setSplunkHec: jest.fn(),
+    setNewRelic: jest.fn()
   },
   feeds: {},
   routes: {},

--- a/test/__mocks__/@adobe/aio-lib-runtime.js
+++ b/test/__mocks__/@adobe/aio-lib-runtime.js
@@ -16,8 +16,7 @@ const mockRtLibInstance = {
     get: jest.fn(),
     setAdobeIoRuntime: jest.fn(),
     setAzureLogAnalytics: jest.fn(),
-    setSplunkHec: jest.fn(),
-    setNewRelic: jest.fn()
+    setSplunkHec: jest.fn()
   },
   feeds: {},
   routes: {},

--- a/test/commands/runtime/namespace/log-forwarding/set.test.js
+++ b/test/commands/runtime/namespace/log-forwarding/set.test.js
@@ -29,6 +29,10 @@ const dataFixtures = [
     port: 'port1',
     index: 'index1',
     hec_token: 'token1'
+  }],
+  ['new_relic', {
+    base_uri: 'uri1',
+    license_key: 'key1'
   }]
 ]
 

--- a/test/commands/runtime/namespace/log-forwarding/set/new-relic-runtime.test.js
+++ b/test/commands/runtime/namespace/log-forwarding/set/new-relic-runtime.test.js
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const RuntimeLib = require('@adobe/aio-lib-runtime')
+const TheCommand = require('../../../../../../src/commands/runtime/namespace/log-forwarding/set/new-relic')
+const { stdout } = require('stdout-stderr')
+
+let command, rtLib
+beforeEach(async () => {
+  command = new TheCommand([])
+  rtLib = await RuntimeLib.init({ apihost: 'fakehost', api_key: 'fakekey' })
+})
+
+test('set log forwarding settings to new_relic', () => {
+  return new Promise(resolve => {
+    const setCall = jest.fn()
+    rtLib.logForwarding.setDestination = setCall
+    command.argv = ['--base-uri', 'uri1', '--license-key', 'key1']
+    return command.run()
+      .then(() => {
+        expect(stdout.output).toMatch(/Log forwarding was set to new_relic for this namespace/)
+        expect(setCall).toBeCalledTimes(1)
+        expect(setCall).toHaveBeenCalledWith('new_relic', { customer_id: 'customer1', shared_key: 'key1', log_type: 'mylog' })
+        resolve()
+      })
+  })
+})
+
+test('failed to set log forwarding settings to new_relic', async () => {
+  rtLib.logForwarding.setDestination = jest.fn().mockRejectedValue(new Error('mocked error'))
+  command.argv = ['--base-uri', 'uri1', '--license-key', 'key1']
+  await expect(command.run()).rejects.toThrow('failed to update log forwarding configuration: mocked error')
+})

--- a/test/commands/runtime/namespace/log-forwarding/set/new-relic-runtime.test.js
+++ b/test/commands/runtime/namespace/log-forwarding/set/new-relic-runtime.test.js
@@ -29,7 +29,7 @@ test('set log forwarding settings to new_relic', () => {
       .then(() => {
         expect(stdout.output).toMatch(/Log forwarding was set to new_relic for this namespace/)
         expect(setCall).toBeCalledTimes(1)
-        expect(setCall).toHaveBeenCalledWith('new_relic', { customer_id: 'customer1', shared_key: 'key1', log_type: 'mylog' })
+        expect(setCall).toHaveBeenCalledWith('new_relic', { base_uri: 'uri1', license_key: 'key1' })
         resolve()
       })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add New Relic support to log forwarding

<!--- Describe your changes in detail -->

## Pre-requisite before merging

- Release of https://github.com/adobe/aio-lib-runtime/pull/148

## Related Issue
[Log forwarding New Relic support](https://github.com/adobe/aio-cli-plugin-runtime/issues/310)
[Add New Relic support to aio CLI](https://github.com/adobe/aio-lib-runtime/pull/148)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Log Forwarding currently supports Splunk and Azure Log Analytics. This PR adds support for New Relic.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Auto tests are included

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
