### PR TITLE
Remove client side validation of Openwhisk flag limits

### DIFF
--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -180,6 +180,10 @@ class ActionCreate extends RuntimeBaseCommand {
         limits = limits || {}
         limits.memory = flags.memory
       }
+      if (flags.concurrency) {
+        limits = limits || {}
+        limits.concurrency = flags.concurrency
+      }
 
       const options = { name }
       if (exec) {
@@ -242,6 +246,10 @@ ActionCreate.limits = {
   logsizeMB: {
     min: 0,
     max: 10
+  },
+  concurrency: {
+    min: 1,
+    max: 500
   }
 }
 
@@ -293,6 +301,12 @@ ActionCreate.flags = {
     description: `the maximum log size LIMIT in MB for the action (default 10, min: ${ActionCreate.limits.logsizeMB.min}, max: ${ActionCreate.limits.logsizeMB.max})`, // help description for flag
     min: ActionCreate.limits.logsizeMB.min,
     max: ActionCreate.limits.logsizeMB.max
+  }),
+  concurrency: Flags.integer({
+    char: 'c',
+    description: `the maximum number of action invocations to send to the same container in parallel (default 200, min: ${ActionCreate.limits.concurrency.min}, max: ${ActionCreate.limits.concurrency.max})`, // help description for flag
+    min: ActionCreate.limits.concurrency.min,
+    max: ActionCreate.limits.concurrency.max
   }),
   kind: Flags.string({
     description: 'the KIND of the action runtime (example: swift:default, nodejs:default)' // help description for flag

--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -246,10 +246,6 @@ ActionCreate.limits = {
   logsizeMB: {
     min: 0,
     max: 10
-  },
-  concurrency: {
-    min: 1,
-    max: 500
   }
 }
 
@@ -304,9 +300,7 @@ ActionCreate.flags = {
   }),
   concurrency: Flags.integer({
     char: 'c',
-    description: `the maximum number of action invocations to send to the same container in parallel (default 200, min: ${ActionCreate.limits.concurrency.min}, max: ${ActionCreate.limits.concurrency.max})`, // help description for flag
-    min: ActionCreate.limits.concurrency.min,
-    max: ActionCreate.limits.concurrency.max
+    description: 'the maximum number of action invocations to send to the same container in parallel (default 200, min: 1, max: 500)' // help description for flag
   }),
   kind: Flags.string({
     description: 'the KIND of the action runtime (example: swift:default, nodejs:default)' // help description for flag

--- a/src/commands/runtime/action/create.js
+++ b/src/commands/runtime/action/create.js
@@ -234,21 +234,6 @@ ActionCreate.args = [
   }
 ]
 
-ActionCreate.limits = {
-  timeoutMs: {
-    min: 100,
-    max: 3600000
-  },
-  memoryMB: {
-    min: 128,
-    max: 4096
-  },
-  logsizeMB: {
-    min: 0,
-    max: 10
-  }
-}
-
 ActionCreate.flags = {
   ...RuntimeBaseCommand.flags,
   param: Flags.string({
@@ -282,21 +267,15 @@ ActionCreate.flags = {
   }),
   timeout: Flags.integer({
     char: 't',
-    description: `the timeout LIMIT in milliseconds after which the action is terminated (default 60000, min: ${ActionCreate.limits.timeoutMs.min}, max: ${ActionCreate.limits.timeoutMs.max})`, // help description for flag
-    min: ActionCreate.limits.timeoutMs.min,
-    max: ActionCreate.limits.timeoutMs.max
+    description: 'the timeout LIMIT in milliseconds after which the action is terminated (default 60000, min: 100, max: 3600000)' // help description for flag
   }),
   memory: Flags.integer({
     char: 'm',
-    description: `the maximum memory LIMIT in MB for the action (default 256, min: ${ActionCreate.limits.memoryMB.min}, max: ${ActionCreate.limits.memoryMB.max})`, // help description for flag
-    min: ActionCreate.limits.memoryMB.min,
-    max: ActionCreate.limits.memoryMB.max
+    description: 'the maximum memory LIMIT in MB for the action (default 256, min: 128, max: 4096)' // help description for flag
   }),
   logsize: Flags.integer({
     char: 'l',
-    description: `the maximum log size LIMIT in MB for the action (default 10, min: ${ActionCreate.limits.logsizeMB.min}, max: ${ActionCreate.limits.logsizeMB.max})`, // help description for flag
-    min: ActionCreate.limits.logsizeMB.min,
-    max: ActionCreate.limits.logsizeMB.max
+    description: 'the maximum log size LIMIT in MB for the action (default 10, min: 0, max: 10)' // help description for flag
   }),
   concurrency: Flags.integer({
     char: 'c',

--- a/src/commands/runtime/action/list.js
+++ b/src/commands/runtime/action/list.js
@@ -101,19 +101,12 @@ ActionList.args = [
   }
 ]
 
-ActionList.limits = {
-  min: 0,
-  max: 50
-}
-
 ActionList.flags = {
   ...RuntimeBaseCommand.flags,
   // example usage:  aio runtime:action:list --limit 10 --skip 2
   limit: Flags.integer({
     char: 'l',
-    description: `only return LIMIT number of actions (min: ${ActionList.limits.min}, max: ${ActionList.limits.max})`,
-    min: ActionList.limits.min,
-    max: ActionList.limits.max
+    description: 'only return LIMIT number of actions (min: 0, max: 50)'
   }),
   skip: Flags.integer({
     char: 's',

--- a/src/commands/runtime/activation/list.js
+++ b/src/commands/runtime/activation/list.js
@@ -204,19 +204,12 @@ ActivationList.args = [
   }
 ]
 
-ActivationList.limits = {
-  min: 0,
-  max: 50
-}
-
 ActivationList.flags = {
   ...RuntimeBaseCommand.flags,
   // example usage:  aio runtime:activation:list --limit 10 --skip 2
   limit: Flags.integer({
     char: 'l',
-    description: `only return LIMIT number of activations (min: ${ActivationList.limits.min}, max: ${ActivationList.limits.max})`,
-    min: ActivationList.limits.min,
-    max: ActivationList.limits.max
+    description: 'only return LIMIT number of activations (min: 0, max: 50)'
   }),
   skip: Flags.integer({
     char: 's',

--- a/src/commands/runtime/activation/logs.js
+++ b/src/commands/runtime/activation/logs.js
@@ -92,11 +92,6 @@ ActivationLogs.args = [
   }
 ]
 
-ActivationLogs.limits = {
-  min: 0,
-  max: 50
-}
-
 ActivationLogs.flags = {
   ...RuntimeBaseCommand.flags,
   action: Flags.string({
@@ -129,10 +124,8 @@ ActivationLogs.flags = {
     default: false
   }),
   limit: Flags.integer({
-    description: `return logs only from last LIMIT number of activations (min: ${ActivationLogs.limits.min}, max: ${ActivationLogs.limits.max})`,
-    exclusive: ['last'],
-    min: ActivationLogs.limits.min,
-    max: ActivationLogs.limits.max
+    description: 'return logs only from last LIMIT number of activations (min: 0, max: 50)',
+    exclusive: ['last']
   }),
   tail: Flags.boolean({
     description: 'Fetch logs continuously',

--- a/src/commands/runtime/package/list.js
+++ b/src/commands/runtime/package/list.js
@@ -86,20 +86,13 @@ class PackageList extends RuntimeBaseCommand {
   }
 }
 
-PackageList.limits = {
-  min: 0,
-  max: 50
-}
-
 PackageList.flags = {
   ...RuntimeBaseCommand.flags,
   // example usage:  aio runtime:package:list --limit 10 --skip 2
   // aio runtime:package:list --count true OR  aio runtime:package:list --count yes
   limit: Flags.integer({
     char: 'l',
-    description: `only return LIMIT number of packages (min: ${PackageList.limits.min}, max: ${PackageList.limits.max})`,
-    min: PackageList.limits.min,
-    max: PackageList.limits.max
+    description: 'only return LIMIT number of packages (min: 0, max: 50)'
   }),
   skip: Flags.integer({
     char: 's',

--- a/src/commands/runtime/rule/list.js
+++ b/src/commands/runtime/rule/list.js
@@ -80,18 +80,11 @@ class RuleList extends RuntimeBaseCommand {
 
 RuleList.description = 'Retrieves a list of Rules'
 
-RuleList.limits = {
-  min: 0,
-  max: 50
-}
-
 RuleList.flags = {
   ...RuntimeBaseCommand.flags,
   limit: Flags.integer({
     char: 'l',
-    description: `Limit number of rules returned (min: ${RuleList.limits.min}, max: ${RuleList.limits.max})`,
-    min: RuleList.limits.min,
-    max: RuleList.limits.max
+    description: 'Limit number of rules returned (min: 0, max: 50)'
   }),
   skip: Flags.integer({
     char: 's',

--- a/src/commands/runtime/trigger/list.js
+++ b/src/commands/runtime/trigger/list.js
@@ -93,18 +93,11 @@ class TriggerList extends RuntimeBaseCommand {
   }
 }
 
-TriggerList.limits = {
-  min: 0,
-  max: 50
-}
-
 TriggerList.flags = {
   ...RuntimeBaseCommand.flags,
   limit: Flags.integer({
     char: 'l',
-    description: `only return LIMIT number of triggers (min: ${TriggerList.limits.min}, max: ${TriggerList.limits.max})`,
-    min: TriggerList.limits.min,
-    max: TriggerList.limits.max,
+    description: 'only return LIMIT number of triggers (min: 0, max: 50)',
     default: 30
   }),
   skip: Flags.integer({

--- a/test/commands/runtime/action/create.test.js
+++ b/test/commands/runtime/action/create.test.js
@@ -836,48 +836,6 @@ describe('instance methods', () => {
       await expect(rejectWithError(command, error, handleError)).toBeTruthy()
     })
 
-    test('errors out on create with timeout below min', async () => {
-      const flag = '--timeout'
-      const invalidValue = '99'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 100 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on create with timeout above max', async () => {
-      const flag = '--timeout'
-      const invalidValue = '3600001'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 3600000 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on create with memory below min', async () => {
-      const flag = '--memory'
-      const invalidValue = '127'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 128 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on create with memory above max', async () => {
-      const flag = '--memory'
-      const invalidValue = '4097'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 4096 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on create with logsize below min', async () => {
-      const flag = '--logsize'
-      const invalidValue = '-1'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on create with logsize above max', async () => {
-      const flag = '--logsize'
-      const invalidValue = '11'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 10 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
     test('errors on --web-secure with --web false flag', async () => {
       rtLib.mockRejected(rtAction, '')
       command.argv = ['hello', '/action/fileWithNoExt', '--web-secure', 'true', '--web', 'false']

--- a/test/commands/runtime/action/create.test.js
+++ b/test/commands/runtime/action/create.test.js
@@ -365,7 +365,7 @@ describe('instance methods', () => {
     test('creates an action with action name, action path, --params flag, limits and kind', () => {
       const name = 'hello'
       const cmd = rtLib.mockResolved(rtAction, { res: 'fake' })
-      command.argv = [name, '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd', '--logsize', '8', '--memory', '128', '--kind', 'nodejs:10']
+      command.argv = [name, '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd', '--logsize', '8', '--memory', '128', '--concurrency', '1', '--kind', 'nodejs:10']
       rtUtils.getKeyValueArrayFromMergedParameters.mockImplementation((flags, file) => flags && ([{ key: 'fakeParam', value: 'aaa' }, { key: 'fakeParam2', value: 'bbb' }]))
       return command.run()
         .then(() => {
@@ -384,7 +384,37 @@ describe('instance methods', () => {
               ],
               limits: {
                 logs: 8,
-                memory: 128
+                memory: 128,
+                concurrency: 1
+              }
+            }
+          })
+          expect(stdout.output).toMatch('')
+        })
+    })
+
+    test('creates an action with action name, action path, --params flag, only concurrency limit and kind', () => {
+      const name = 'hello'
+      const cmd = rtLib.mockResolved(rtAction, { res: 'fake' })
+      command.argv = [name, '/action/actionFile.js', '--param', 'a', 'b', '--param', 'c', 'd', '--concurrency', '1', '--kind', 'nodejs:10']
+      rtUtils.getKeyValueArrayFromMergedParameters.mockImplementation((flags, file) => flags && ([{ key: 'fakeParam', value: 'aaa' }, { key: 'fakeParam2', value: 'bbb' }]))
+      return command.run()
+        .then(() => {
+          expect(rtUtils.getKeyValueArrayFromMergedParameters).toHaveBeenCalledWith(['a', 'b', 'c', 'd'], undefined)
+          expect(cmd).toHaveBeenCalledWith({
+            name,
+            action: {
+              name,
+              exec: {
+                code: jsFile,
+                kind: 'nodejs:10'
+              },
+              parameters: [
+                { key: 'fakeParam', value: 'aaa' },
+                { key: 'fakeParam2', value: 'bbb' }
+              ],
+              limits: {
+                concurrency: 1
               }
             }
           })
@@ -846,6 +876,20 @@ describe('instance methods', () => {
       const invalidValue = '11'
       command.argv = [flag, invalidValue]
       await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 10 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on create with concurrency below min', async () => {
+      const flag = '--concurrency'
+      const invalidValue = '0'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 1 but received: ${invalidValue}\nSee more help with --help`)
+    })
+
+    test('errors out on create with concurrency above max', async () => {
+      const flag = '--concurrency'
+      const invalidValue = '501'
+      command.argv = [flag, invalidValue]
+      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 500 but received: ${invalidValue}\nSee more help with --help`)
     })
 
     test('errors on --web-secure with --web false flag', async () => {

--- a/test/commands/runtime/action/create.test.js
+++ b/test/commands/runtime/action/create.test.js
@@ -878,20 +878,6 @@ describe('instance methods', () => {
       await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 10 but received: ${invalidValue}\nSee more help with --help`)
     })
 
-    test('errors out on create with concurrency below min', async () => {
-      const flag = '--concurrency'
-      const invalidValue = '0'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 1 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on create with concurrency above max', async () => {
-      const flag = '--concurrency'
-      const invalidValue = '501'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 500 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
     test('errors on --web-secure with --web false flag', async () => {
       rtLib.mockRejected(rtAction, '')
       command.argv = ['hello', '/action/fileWithNoExt', '--web-secure', 'true', '--web', 'false']

--- a/test/commands/runtime/action/list.test.js
+++ b/test/commands/runtime/action/list.test.js
@@ -165,20 +165,6 @@ describe('instance methods', () => {
       expect(handleError).toHaveBeenLastCalledWith('failed to list the actions', new Error('an error'))
     })
 
-    test('errors out on list with limit below min', async () => {
-      const flag = '--limit'
-      const invalidValue = '-1'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on list with limit above max', async () => {
-      const flag = '--limit'
-      const invalidValue = '51'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
     test('return list of actions with annotated kinds', () => {
       const data = [
         {

--- a/test/commands/runtime/activation/list.test.js
+++ b/test/commands/runtime/activation/list.test.js
@@ -390,20 +390,6 @@ describe('instance methods', () => {
       expect(handleError).toHaveBeenLastCalledWith('failed to list the activations', new Error('an error'))
     })
 
-    test('errors out on list with limit below min', async () => {
-      const flag = '--limit'
-      const invalidValue = '-1'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on list with limit above max', async () => {
-      const flag = '--limit'
-      const invalidValue = '51'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
     test('ignore activation without annotations', () => {
       const data = [
         {

--- a/test/commands/runtime/activation/logs.test.js
+++ b/test/commands/runtime/activation/logs.test.js
@@ -109,20 +109,6 @@ describe('instance methods', () => {
       expect(handleError).toHaveBeenCalledWith('failed to retrieve logs for activation', expect.any(Error))
     })
 
-    test('errors out on list with limit below min', async () => {
-      const flag = '--limit'
-      const invalidValue = '-1'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on list with limit above max', async () => {
-      const flag = '--limit'
-      const invalidValue = '51'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
     test('retrieve last log (default)', () => {
       command.argv = []
       return command.run()

--- a/test/commands/runtime/package/list.test.js
+++ b/test/commands/runtime/package/list.test.js
@@ -168,19 +168,5 @@ describe('instance methods', () => {
           expect(JSON.parse(stdout.output)).toEqual({ packages: 2 })
         })
     })
-
-    test('errors out on list with limit below min', async () => {
-      const flag = '--limit'
-      const invalidValue = '-1'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on list with limit above max', async () => {
-      const flag = '--limit'
-      const invalidValue = '51'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
-    })
   })
 })

--- a/test/commands/runtime/rule/list.test.js
+++ b/test/commands/runtime/rule/list.test.js
@@ -213,19 +213,5 @@ describe('instance methods', () => {
       await expect(command.run()).rejects.toThrow(...error)
       expect(handleError).toHaveBeenLastCalledWith(...error)
     })
-
-    test('errors out on list with limit below min', async () => {
-      const flag = '--limit'
-      const invalidValue = '-1'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on list with limit above max', async () => {
-      const flag = '--limit'
-      const invalidValue = '51'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
-    })
   })
 })

--- a/test/commands/runtime/trigger/list.test.js
+++ b/test/commands/runtime/trigger/list.test.js
@@ -211,20 +211,6 @@ describe('instance methods', () => {
       expect(handleError).toHaveBeenLastCalledWith(...error)
     })
 
-    test('errors out on list with limit below min', async () => {
-      const flag = '--limit'
-      const invalidValue = '-1'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer greater than or equal to 0 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
-    test('errors out on list with limit above max', async () => {
-      const flag = '--limit'
-      const invalidValue = '51'
-      command.argv = [flag, invalidValue]
-      await expect(command.run()).rejects.toThrow(`Parsing ${flag} \n\tExpected an integer less than or equal to 50 but received: ${invalidValue}\nSee more help with --help`)
-    })
-
     test('return list of triggers, --name-sort flag', () => {
       const cmd = rtLib.mockResolvedFixture(rtAction, 'trigger/list-name-sort.json')
       command.argv = ['--name']


### PR DESCRIPTION
## Description

Remove client side validation of Openwhisk flag limits. We shouldn't be doing client-side validation for these Openwhisk limits. The errors returned from the server are sufficient enough 

## Related Issue

## Motivation and Context

Remove bloat and the need to track these values in multiple places

## How Has This Been Tested?

Locally linked plugin and `npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
