### PR TITLE
fix: ACNA-2807 - code links in README point to a .ts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ ALIASES
   $ aio rt
 ```
 
-_See code: [src/commands/runtime/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/index.ts)_
+_See code: [src/commands/runtime/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/index.js)_
 
 ## `aio runtime action`
 
@@ -161,7 +161,7 @@ ALIASES
   $ aio rt action
 ```
 
-_See code: [src/commands/runtime/action/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/index.ts)_
+_See code: [src/commands/runtime/action/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/index.js)_
 
 ## `aio runtime action create ACTIONNAME [ACTIONPATH]`
 
@@ -217,7 +217,7 @@ ALIASES
   $ aio rt action create
 ```
 
-_See code: [src/commands/runtime/action/create.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/create.ts)_
+_See code: [src/commands/runtime/action/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/create.js)_
 
 ## `aio runtime action delete ACTIONNAME`
 
@@ -250,7 +250,7 @@ ALIASES
   $ aio rt action del
 ```
 
-_See code: [src/commands/runtime/action/delete.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/delete.ts)_
+_See code: [src/commands/runtime/action/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/delete.js)_
 
 ## `aio runtime action get ACTIONNAME`
 
@@ -284,7 +284,7 @@ ALIASES
   $ aio rt action get
 ```
 
-_See code: [src/commands/runtime/action/get.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/get.ts)_
+_See code: [src/commands/runtime/action/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/get.js)_
 
 ## `aio runtime action invoke ACTIONNAME`
 
@@ -318,7 +318,7 @@ ALIASES
   $ aio rt action invoke
 ```
 
-_See code: [src/commands/runtime/action/invoke.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/invoke.ts)_
+_See code: [src/commands/runtime/action/invoke.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/invoke.js)_
 
 ## `aio runtime action list [PACKAGENAME]`
 
@@ -360,7 +360,7 @@ ALIASES
   $ aio rt actions ls
 ```
 
-_See code: [src/commands/runtime/action/list.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/list.ts)_
+_See code: [src/commands/runtime/action/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/list.js)_
 
 ## `aio runtime action update ACTIONNAME [ACTIONPATH]`
 
@@ -416,7 +416,7 @@ ALIASES
   $ aio rt action update
 ```
 
-_See code: [src/commands/runtime/action/update.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/update.ts)_
+_See code: [src/commands/runtime/action/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/action/update.js)_
 
 ## `aio runtime activation`
 
@@ -446,7 +446,7 @@ ALIASES
   $ aio rt activation
 ```
 
-_See code: [src/commands/runtime/activation/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/index.ts)_
+_See code: [src/commands/runtime/activation/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/index.js)_
 
 ## `aio runtime activation get [ACTIVATIONID]`
 
@@ -478,7 +478,7 @@ ALIASES
   $ aio rt activation get
 ```
 
-_See code: [src/commands/runtime/activation/get.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/get.ts)_
+_See code: [src/commands/runtime/activation/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/get.js)_
 
 ## `aio runtime activation list [ACTION_NAME]`
 
@@ -524,7 +524,7 @@ ALIASES
   $ aio rt activations ls
 ```
 
-_See code: [src/commands/runtime/activation/list.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/list.ts)_
+_See code: [src/commands/runtime/activation/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/list.js)_
 
 ## `aio runtime activation logs [ACTIVATIONID]`
 
@@ -571,7 +571,7 @@ ALIASES
   $ aio rt logs
 ```
 
-_See code: [src/commands/runtime/activation/logs.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/logs.ts)_
+_See code: [src/commands/runtime/activation/logs.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/logs.js)_
 
 ## `aio runtime activation result [ACTIVATIONID]`
 
@@ -602,7 +602,7 @@ ALIASES
   $ aio rt activation result
 ```
 
-_See code: [src/commands/runtime/activation/result.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/result.ts)_
+_See code: [src/commands/runtime/activation/result.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/activation/result.js)_
 
 ## `aio runtime api`
 
@@ -634,7 +634,7 @@ ALIASES
   $ aio rt route
 ```
 
-_See code: [src/commands/runtime/api/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/index.ts)_
+_See code: [src/commands/runtime/api/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/index.js)_
 
 ## `aio runtime api create [BASEPATH] [RELPATH] [APIVERB] [ACTION]`
 
@@ -677,7 +677,7 @@ ALIASES
   $ aio rt api create
 ```
 
-_See code: [src/commands/runtime/api/create.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/create.ts)_
+_See code: [src/commands/runtime/api/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/create.js)_
 
 ## `aio runtime api delete BASEPATHORAPINAME [RELPATH] [APIVERB]`
 
@@ -714,7 +714,7 @@ ALIASES
   $ aio rt api delete
 ```
 
-_See code: [src/commands/runtime/api/delete.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/delete.ts)_
+_See code: [src/commands/runtime/api/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/delete.js)_
 
 ## `aio runtime api get BASEPATHORAPINAME`
 
@@ -749,7 +749,7 @@ ALIASES
   $ aio rt api get
 ```
 
-_See code: [src/commands/runtime/api/get.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/get.ts)_
+_See code: [src/commands/runtime/api/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/get.js)_
 
 ## `aio runtime api list [BASEPATH] [RELPATH] [APIVERB]`
 
@@ -793,7 +793,7 @@ ALIASES
   $ aio rt route ls
 ```
 
-_See code: [src/commands/runtime/api/list.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/list.ts)_
+_See code: [src/commands/runtime/api/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/api/list.js)_
 
 ## `aio runtime deploy`
 
@@ -827,7 +827,7 @@ ALIASES
   $ aio rt deploy
 ```
 
-_See code: [src/commands/runtime/deploy/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/index.ts)_
+_See code: [src/commands/runtime/deploy/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/index.js)_
 
 ## `aio runtime deploy export`
 
@@ -859,7 +859,7 @@ ALIASES
   $ aio rt deploy export
 ```
 
-_See code: [src/commands/runtime/deploy/export.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/export.ts)_
+_See code: [src/commands/runtime/deploy/export.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/export.js)_
 
 ## `aio runtime deploy report`
 
@@ -891,7 +891,7 @@ ALIASES
   $ aio rt deploy report
 ```
 
-_See code: [src/commands/runtime/deploy/report.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/report.ts)_
+_See code: [src/commands/runtime/deploy/report.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/report.js)_
 
 ## `aio runtime deploy sync`
 
@@ -924,7 +924,7 @@ ALIASES
   $ aio rt deploy sync
 ```
 
-_See code: [src/commands/runtime/deploy/sync.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/sync.ts)_
+_See code: [src/commands/runtime/deploy/sync.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/sync.js)_
 
 ## `aio runtime deploy undeploy`
 
@@ -956,7 +956,7 @@ ALIASES
   $ aio rt deploy undeploy
 ```
 
-_See code: [src/commands/runtime/deploy/undeploy.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/undeploy.ts)_
+_See code: [src/commands/runtime/deploy/undeploy.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/undeploy.js)_
 
 ## `aio runtime deploy version`
 
@@ -986,7 +986,7 @@ ALIASES
   $ aio rt deploy version
 ```
 
-_See code: [src/commands/runtime/deploy/version.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/version.ts)_
+_See code: [src/commands/runtime/deploy/version.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/deploy/version.js)_
 
 ## `aio runtime namespace`
 
@@ -1018,7 +1018,7 @@ ALIASES
   $ aio rt ns
 ```
 
-_See code: [src/commands/runtime/namespace/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/index.ts)_
+_See code: [src/commands/runtime/namespace/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/index.js)_
 
 ## `aio runtime namespace get`
 
@@ -1055,7 +1055,7 @@ ALIASES
   $ aio rt ls
 ```
 
-_See code: [src/commands/runtime/namespace/get.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/get.ts)_
+_See code: [src/commands/runtime/namespace/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/get.js)_
 
 ## `aio runtime namespace list`
 
@@ -1092,7 +1092,7 @@ ALIASES
   $ aio rt ns ls
 ```
 
-_See code: [src/commands/runtime/namespace/list.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/list.ts)_
+_See code: [src/commands/runtime/namespace/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/list.js)_
 
 ## `aio runtime namespace log-forwarding`
 
@@ -1128,7 +1128,7 @@ ALIASES
   $ aio rt ns lf
 ```
 
-_See code: [src/commands/runtime/namespace/log-forwarding/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/index.ts)_
+_See code: [src/commands/runtime/namespace/log-forwarding/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/index.js)_
 
 ## `aio runtime namespace log-forwarding errors`
 
@@ -1164,7 +1164,7 @@ ALIASES
   $ aio rt ns lf errors
 ```
 
-_See code: [src/commands/runtime/namespace/log-forwarding/errors.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/errors.ts)_
+_See code: [src/commands/runtime/namespace/log-forwarding/errors.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/errors.js)_
 
 ## `aio runtime namespace log-forwarding get`
 
@@ -1200,7 +1200,7 @@ ALIASES
   $ aio rt ns lf get
 ```
 
-_See code: [src/commands/runtime/namespace/log-forwarding/get.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/get.ts)_
+_See code: [src/commands/runtime/namespace/log-forwarding/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/get.js)_
 
 ## `aio runtime namespace log-forwarding set`
 
@@ -1236,7 +1236,7 @@ ALIASES
   $ aio rt ns lf set
 ```
 
-_See code: [src/commands/runtime/namespace/log-forwarding/set.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set.ts)_
+_See code: [src/commands/runtime/namespace/log-forwarding/set.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set.js)_
 
 ## `aio runtime namespace log-forwarding set adobe-io-runtime`
 
@@ -1272,7 +1272,7 @@ ALIASES
   $ aio rt ns lf set adobe-io-runtime
 ```
 
-_See code: [src/commands/runtime/namespace/log-forwarding/set/adobe-io-runtime.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set/adobe-io-runtime.ts)_
+_See code: [src/commands/runtime/namespace/log-forwarding/set/adobe-io-runtime.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set/adobe-io-runtime.js)_
 
 ## `aio runtime namespace log-forwarding set azure-log-analytics`
 
@@ -1311,7 +1311,7 @@ ALIASES
   $ aio rt ns lf set azure-log-analytics
 ```
 
-_See code: [src/commands/runtime/namespace/log-forwarding/set/azure-log-analytics.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set/azure-log-analytics.ts)_
+_See code: [src/commands/runtime/namespace/log-forwarding/set/azure-log-analytics.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set/azure-log-analytics.js)_
 
 ## `aio runtime namespace log-forwarding set new-relic`
 
@@ -1349,7 +1349,7 @@ ALIASES
   $ aio rt ns lf set new-relic
 ```
 
-_See code: [src/commands/runtime/namespace/log-forwarding/set/new-relic.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set/new-relic.ts)_
+_See code: [src/commands/runtime/namespace/log-forwarding/set/new-relic.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set/new-relic.js)_
 
 ## `aio runtime namespace log-forwarding set splunk-hec`
 
@@ -1389,7 +1389,7 @@ ALIASES
   $ aio rt ns lf set splunk-hec
 ```
 
-_See code: [src/commands/runtime/namespace/log-forwarding/set/splunk-hec.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set/splunk-hec.ts)_
+_See code: [src/commands/runtime/namespace/log-forwarding/set/splunk-hec.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/namespace/log-forwarding/set/splunk-hec.js)_
 
 ## `aio runtime package`
 
@@ -1421,7 +1421,7 @@ ALIASES
   $ aio rt pkg
 ```
 
-_See code: [src/commands/runtime/package/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/index.ts)_
+_See code: [src/commands/runtime/package/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/index.js)_
 
 ## `aio runtime package bind PACKAGENAME BINDPACKAGENAME`
 
@@ -1459,7 +1459,7 @@ ALIASES
   $ aio rt pkg bind
 ```
 
-_See code: [src/commands/runtime/package/bind.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/bind.ts)_
+_See code: [src/commands/runtime/package/bind.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/bind.js)_
 
 ## `aio runtime package create PACKAGENAME`
 
@@ -1499,7 +1499,7 @@ ALIASES
   $ aio rt pkg create
 ```
 
-_See code: [src/commands/runtime/package/create.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/create.ts)_
+_See code: [src/commands/runtime/package/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/create.js)_
 
 ## `aio runtime package delete PACKAGENAME`
 
@@ -1533,7 +1533,7 @@ ALIASES
   $ aio rt pkg delete
 ```
 
-_See code: [src/commands/runtime/package/delete.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/delete.ts)_
+_See code: [src/commands/runtime/package/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/delete.js)_
 
 ## `aio runtime package get PACKAGENAME`
 
@@ -1565,7 +1565,7 @@ ALIASES
   $ aio rt pkg get
 ```
 
-_See code: [src/commands/runtime/package/get.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/get.ts)_
+_See code: [src/commands/runtime/package/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/get.js)_
 
 ## `aio runtime package list [NAMESPACE]`
 
@@ -1607,7 +1607,7 @@ ALIASES
   $ aio rt pkg ls
 ```
 
-_See code: [src/commands/runtime/package/list.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/list.ts)_
+_See code: [src/commands/runtime/package/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/list.js)_
 
 ## `aio runtime package update PACKAGENAME`
 
@@ -1647,7 +1647,7 @@ ALIASES
   $ aio rt pkg update
 ```
 
-_See code: [src/commands/runtime/package/update.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/update.ts)_
+_See code: [src/commands/runtime/package/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/package/update.js)_
 
 ## `aio runtime property`
 
@@ -1679,7 +1679,7 @@ ALIASES
   $ aio rt property
 ```
 
-_See code: [src/commands/runtime/property/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/property/index.ts)_
+_See code: [src/commands/runtime/property/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/property/index.js)_
 
 ## `aio runtime property get`
 
@@ -1716,7 +1716,7 @@ ALIASES
   $ aio rt prop get
 ```
 
-_See code: [src/commands/runtime/property/get.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/property/get.ts)_
+_See code: [src/commands/runtime/property/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/property/get.js)_
 
 ## `aio runtime property set`
 
@@ -1749,7 +1749,7 @@ ALIASES
   $ aio rt prop set
 ```
 
-_See code: [src/commands/runtime/property/set.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/property/set.ts)_
+_See code: [src/commands/runtime/property/set.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/property/set.js)_
 
 ## `aio runtime property unset`
 
@@ -1782,7 +1782,7 @@ ALIASES
   $ aio rt prop unset
 ```
 
-_See code: [src/commands/runtime/property/unset.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/property/unset.ts)_
+_See code: [src/commands/runtime/property/unset.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/property/unset.js)_
 
 ## `aio runtime rule`
 
@@ -1812,7 +1812,7 @@ ALIASES
   $ aio rt rule
 ```
 
-_See code: [src/commands/runtime/rule/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/index.ts)_
+_See code: [src/commands/runtime/rule/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/index.js)_
 
 ## `aio runtime rule create NAME TRIGGER ACTION`
 
@@ -1848,7 +1848,7 @@ ALIASES
   $ aio rt rule create
 ```
 
-_See code: [src/commands/runtime/rule/create.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/create.ts)_
+_See code: [src/commands/runtime/rule/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/create.js)_
 
 ## `aio runtime rule delete NAME`
 
@@ -1882,7 +1882,7 @@ ALIASES
   $ aio rt rule delete
 ```
 
-_See code: [src/commands/runtime/rule/delete.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/delete.ts)_
+_See code: [src/commands/runtime/rule/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/delete.js)_
 
 ## `aio runtime rule disable NAME`
 
@@ -1915,7 +1915,7 @@ ALIASES
   $ aio rt rule disable
 ```
 
-_See code: [src/commands/runtime/rule/disable.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/disable.ts)_
+_See code: [src/commands/runtime/rule/disable.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/disable.js)_
 
 ## `aio runtime rule enable NAME`
 
@@ -1948,7 +1948,7 @@ ALIASES
   $ aio rt rule enable
 ```
 
-_See code: [src/commands/runtime/rule/enable.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/enable.ts)_
+_See code: [src/commands/runtime/rule/enable.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/enable.js)_
 
 ## `aio runtime rule get NAME`
 
@@ -1981,7 +1981,7 @@ ALIASES
   $ aio rt rule get
 ```
 
-_See code: [src/commands/runtime/rule/get.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/get.ts)_
+_See code: [src/commands/runtime/rule/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/get.js)_
 
 ## `aio runtime rule list`
 
@@ -2019,7 +2019,7 @@ ALIASES
   $ aio rt rule ls
 ```
 
-_See code: [src/commands/runtime/rule/list.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/list.ts)_
+_See code: [src/commands/runtime/rule/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/list.js)_
 
 ## `aio runtime rule status NAME`
 
@@ -2052,7 +2052,7 @@ ALIASES
   $ aio rt rule status
 ```
 
-_See code: [src/commands/runtime/rule/status.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/status.ts)_
+_See code: [src/commands/runtime/rule/status.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/status.js)_
 
 ## `aio runtime rule update NAME TRIGGER ACTION`
 
@@ -2088,7 +2088,7 @@ ALIASES
   $ aio rt rule update
 ```
 
-_See code: [src/commands/runtime/rule/update.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/update.ts)_
+_See code: [src/commands/runtime/rule/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/rule/update.js)_
 
 ## `aio runtime trigger`
 
@@ -2118,7 +2118,7 @@ ALIASES
   $ aio rt trigger
 ```
 
-_See code: [src/commands/runtime/trigger/index.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/index.ts)_
+_See code: [src/commands/runtime/trigger/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/index.js)_
 
 ## `aio runtime trigger create TRIGGERNAME`
 
@@ -2156,7 +2156,7 @@ ALIASES
   $ aio rt trigger create
 ```
 
-_See code: [src/commands/runtime/trigger/create.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/create.ts)_
+_See code: [src/commands/runtime/trigger/create.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/create.js)_
 
 ## `aio runtime trigger delete TRIGGERPATH`
 
@@ -2189,7 +2189,7 @@ ALIASES
   $ aio rt trigger delete
 ```
 
-_See code: [src/commands/runtime/trigger/delete.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/delete.ts)_
+_See code: [src/commands/runtime/trigger/delete.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/delete.js)_
 
 ## `aio runtime trigger fire TRIGGERNAME`
 
@@ -2224,7 +2224,7 @@ ALIASES
   $ aio rt trigger fire
 ```
 
-_See code: [src/commands/runtime/trigger/fire.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/fire.ts)_
+_See code: [src/commands/runtime/trigger/fire.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/fire.js)_
 
 ## `aio runtime trigger get TRIGGERPATH`
 
@@ -2257,7 +2257,7 @@ ALIASES
   $ aio rt trigger get
 ```
 
-_See code: [src/commands/runtime/trigger/get.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/get.ts)_
+_See code: [src/commands/runtime/trigger/get.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/get.js)_
 
 ## `aio runtime trigger list`
 
@@ -2295,7 +2295,7 @@ ALIASES
   $ aio rt trigger ls
 ```
 
-_See code: [src/commands/runtime/trigger/list.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/list.ts)_
+_See code: [src/commands/runtime/trigger/list.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/list.js)_
 
 ## `aio runtime trigger update TRIGGERNAME`
 
@@ -2332,7 +2332,7 @@ ALIASES
   $ aio rt trigger update
 ```
 
-_See code: [src/commands/runtime/trigger/update.ts](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/update.ts)_
+_See code: [src/commands/runtime/trigger/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/7.0.0/src/commands/runtime/trigger/update.js)_
 <!-- commandsstop -->
 
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "sha1": "^1.1.1"
   },
   "devDependencies": {
-    "@adobe/eslint-config-aio-lib-config": "^2.0.1",
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
     "@babel/core": "^7.16.12",
     "@babel/preset-env": "^7.16.11",
     "babel-jest": "^29.5.0",
@@ -46,8 +46,7 @@
     "jest-junit": "^16.0.0",
     "jest-plugin-fs": "^2.9.0",
     "oclif": "^3.2.0",
-    "stdout-stderr": "^0.1.9",
-    "typescript": "^5.1.6"
+    "stdout-stderr": "^0.1.9"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
closes #332 

## How Has This Been Tested?

1. rm -rf node_modules
2. npm i
3. npm test
4. npm run prepack
5. Inspect README.md for `See code:` links (should point to the `.js` file)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
