### PR TITLE
fix: error when current context is undefined, CLI symbol is undefined

### DIFF
--- a/src/DeployServiceCommand.js
+++ b/src/DeployServiceCommand.js
@@ -38,7 +38,7 @@ class DeployServiceCommand extends RuntimeBaseCommand {
     let contextName = CLI // default
     const currentContext = await context.getCurrent() // potential override
 
-    if (currentContext !== CLI) {
+    if (currentContext && currentContext !== CLI) {
       contextName = currentContext
     } else {
       await context.setCli({ 'cli.bare-output': true }, false) // set this globally

--- a/src/DeployServiceCommand.js
+++ b/src/DeployServiceCommand.js
@@ -14,7 +14,8 @@ const { Flags } = require('@oclif/core')
 
 const { PropertyDefault } = require('./properties')
 const runtimeLib = require('@adobe/aio-lib-runtime')
-const { getToken, context, CLI } = require('@adobe/aio-lib-ims')
+const { getToken, context } = require('@adobe/aio-lib-ims')
+const { CLI } = require('@adobe/aio-lib-ims/src/context')
 const { getCliEnv } = require('@adobe/aio-lib-env')
 const RuntimeBaseCommand = require('./RuntimeBaseCommand')
 

--- a/test/DeployServiceCommand.test.js
+++ b/test/DeployServiceCommand.test.js
@@ -62,8 +62,8 @@ describe('DeployServiceCommand', () => {
       getCliEnv.mockReturnValue(mockEnv)
     })
 
-    test('should use CLI context by default', async () => {
-      context.getCurrent.mockResolvedValue(CLI)
+    test('should use CLI context (default) if current context undefined', async () => {
+      context.getCurrent.mockResolvedValue(undefined)
       getToken.mockResolvedValue(mockToken)
 
       const result = await command.getAccessToken()


### PR DESCRIPTION
In an AB project:
```
❯ aio rt trigger create trigger123
 ›   Error: failed to create the trigger: Unknown Error From API: [IMSSDK:CONTEXT_NOT_CONFIGURED] IMS context '%s' is
 ›   not configured
 ›    specify --verbose flag for more information
```

## Description

When the current ims context is not set, you can't get an access token. A truthy check was missing.

## How Has This Been Tested?

- `aio plugins link .` to this PR branch
- delete any ims login via `aio config del ims`
- Go to the root of an AB project
- `aio rt trigger create trigger123`
- should not error

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
