### PR TITLE
ACNA-4221: fixing alias rt to display help commands [draft]

### DIFF
--- a/src/commands/runtime/index.js
+++ b/src/commands/runtime/index.js
@@ -16,7 +16,7 @@ const RuntimeBaseCommand = require('../../RuntimeBaseCommand')
 class IndexCommand extends RuntimeBaseCommand {
   async run () {
     const help = new Help(this.config)
-    await help.showHelp(['runtime', '--help'])
+    await help.showHelp([this.id])
   }
 }
 

--- a/test/commands/runtime/index.test.js
+++ b/test/commands/runtime/index.test.js
@@ -52,8 +52,9 @@ describe('instance methods', () => {
     test('returns help file for runtime command', () => {
       const spy = jest.spyOn(Help.prototype, 'showHelp').mockReturnValue(true)
       command.config = {}
+      command.id = 'runtime' // Set the command ID for the test
       return command.run().then(() => {
-        expect(spy).toHaveBeenCalledWith(['runtime', '--help'])
+        expect(spy).toHaveBeenCalledWith(['runtime'])
       })
     })
   })


### PR DESCRIPTION
**Fix: Display subcommands for 'rt --help' command**

## Problem
`aio rt --help` only shows flags, missing TOPICS and COMMANDS sections.
`aio runtime --help` works correctly.

Closes #[issue-number](https://github.com/adobe/aio-cli/issues/769)

## Root Cause
oclif's Help system doesn't recognize `rt` as an alias for a topic with subcommands.

## Solution
Added custom help class in main aio-cli repository to intercept the help before hitting ocliff's main.js - help class
- Intercepts `aio rt --help` requests
- Shows help for `runtime` instead of `rt`
- Exits before oclif's default help runs

## Testing

- All 799 tests pass
- Added 3 new tests for hook coverage
- Manual testing:
-   `aio rt --help` → Shows subcommands 
-   `aio runtime --help` → Still works 
-   `aio rt` (no flag) → Shows subcommands 

```


## Types of changes

- [X ] Bug fix (non-breaking change which fixes an issue)

**Added files:**
src/hooks/init/AliasHelpHook.js - Init hook to intercept and redirect help
test/hooks/init/AliasHelpHook.test.js - Test coverage for the hook

**Modified existing files:**
src/commands/runtime/index.js - Changed to use this.id dynamically


## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
