### PR TITLE
fix: include URL in api list --json output

### DIFF
--- a/src/commands/runtime/api/list.js
+++ b/src/commands/runtime/api/list.js
@@ -56,11 +56,6 @@ class ApiList extends RuntimeBaseCommand {
 
       const result = await ow.routes.list(options)
 
-      if (shouldOutputJson) {
-        this.logJSON('', result.apis[0].value.apidoc)
-        return
-      }
-
       let data = []
       result.apis.forEach(api => {
         // join the two arrays by reduce
@@ -69,6 +64,11 @@ class ApiList extends RuntimeBaseCommand {
           return coll
         }, data)
       })
+
+      if (shouldOutputJson) {
+        this.logJSON('', data)
+        return
+      }
 
       table(data, {
         Action: { minWidth: 10 },

--- a/src/commands/runtime/api/list.js
+++ b/src/commands/runtime/api/list.js
@@ -60,9 +60,13 @@ class ApiList extends RuntimeBaseCommand {
         if (!result.apis || result.apis.length === 0) {
           this.logJSON('', {})
         const api = result.apis[0]
+        const api = result.apis && result.apis[0]
         if (!api || !api.value) {
-
-        const api = result.apis[0]
+          this.logJSON('', {})
+          return
+        }
+        const apidoc = api.value.apidoc
+        const gwApiUrl = api.value.gwApiUrl
         const apidoc = api.value.apidoc
         const gwApiUrl = api.value.gwApiUrl
         Object.keys(apidoc.paths).forEach(path => {

--- a/src/commands/runtime/api/list.js
+++ b/src/commands/runtime/api/list.js
@@ -60,7 +60,7 @@ class ApiList extends RuntimeBaseCommand {
         const api = result.apis && result.apis[0]
         if (!api || !api.value) {
           this.logJSON('', {})
-          return
+        Object.keys(apidoc.paths || {}).forEach(path => {
         }
         const apidoc = api.value.apidoc
         const gwApiUrl = api.value.gwApiUrl

--- a/src/commands/runtime/api/list.js
+++ b/src/commands/runtime/api/list.js
@@ -57,6 +57,11 @@ class ApiList extends RuntimeBaseCommand {
       const result = await ow.routes.list(options)
 
       if (shouldOutputJson) {
+        if (!result.apis || result.apis.length === 0) {
+          this.logJSON('', {})
+          return
+        }
+
         const api = result.apis[0]
         const apidoc = api.value.apidoc
         const gwApiUrl = api.value.gwApiUrl

--- a/src/commands/runtime/api/list.js
+++ b/src/commands/runtime/api/list.js
@@ -57,16 +57,11 @@ class ApiList extends RuntimeBaseCommand {
       const result = await ow.routes.list(options)
 
       if (shouldOutputJson) {
-        if (!result.apis || result.apis.length === 0) {
-          this.logJSON('', {})
-        const api = result.apis[0]
         const api = result.apis && result.apis[0]
         if (!api || !api.value) {
           this.logJSON('', {})
           return
         }
-        const apidoc = api.value.apidoc
-        const gwApiUrl = api.value.gwApiUrl
         const apidoc = api.value.apidoc
         const gwApiUrl = api.value.gwApiUrl
         Object.keys(apidoc.paths).forEach(path => {

--- a/src/commands/runtime/api/list.js
+++ b/src/commands/runtime/api/list.js
@@ -56,6 +56,23 @@ class ApiList extends RuntimeBaseCommand {
 
       const result = await ow.routes.list(options)
 
+      if (shouldOutputJson) {
+        const api = result.apis[0]
+        const apidoc = api.value.apidoc
+        const gwApiUrl = api.value.gwApiUrl
+        Object.keys(apidoc.paths).forEach(path => {
+          if (!path.startsWith('/')) return
+          Object.keys(apidoc.paths[path]).forEach(verb => {
+            const operation = apidoc.paths[path][verb]
+            if (operation['x-openwhisk']) {
+              operation['x-openwhisk'].url = `${gwApiUrl}${path}`
+            }
+          })
+        })
+        this.logJSON('', apidoc)
+        return
+      }
+
       let data = []
       result.apis.forEach(api => {
         // join the two arrays by reduce
@@ -64,11 +81,6 @@ class ApiList extends RuntimeBaseCommand {
           return coll
         }, data)
       })
-
-      if (shouldOutputJson) {
-        this.logJSON('', data)
-        return
-      }
 
       table(data, {
         Action: { minWidth: 10 },

--- a/src/commands/runtime/api/list.js
+++ b/src/commands/runtime/api/list.js
@@ -59,8 +59,8 @@ class ApiList extends RuntimeBaseCommand {
       if (shouldOutputJson) {
         if (!result.apis || result.apis.length === 0) {
           this.logJSON('', {})
-          return
-        }
+        const api = result.apis[0]
+        if (!api || !api.value) {
 
         const api = result.apis[0]
         const apidoc = api.value.apidoc

--- a/test/commands/runtime/api/list.test.js
+++ b/test/commands/runtime/api/list.test.js
@@ -119,6 +119,23 @@ describe('instance methods', () => {
         })
     })
 
+    test('--json flag, empty apis array returns empty object', () => {
+      rtLib.mockResolved(rtAction, { apis: [] })
+      stdout.stop()
+      stdout.start()
+      const cmd = new TheCommand(['--json'])
+      return cmd.run()
+        .then(() => {
+          const output = stdout.output.trim()
+          const jsonMatch = output.match(/\{[\s\S]*\}$/)
+          const parsed = JSON.parse(jsonMatch ? jsonMatch[0] : output)
+          expect(parsed).toEqual({})
+        })
+        .finally(() => {
+          stdout.stop()
+        })
+    })
+
     test('--json flag, operation without x-openwhisk leaves url unchanged', () => {
       rtLib.mockResolved(rtAction, {
         apis: [{

--- a/test/commands/runtime/api/list.test.js
+++ b/test/commands/runtime/api/list.test.js
@@ -102,9 +102,13 @@ describe('instance methods', () => {
         .then(() => {
           const expectedJson = fixtureJson('api/list.json')
           const output = stdout.output.trim()
-          const jsonMatch = output.match(/\{[\s\S]*\}$/)
+          const jsonMatch = output.match(/\[[\s\S]*\]$/)
           const jsonOutput = jsonMatch ? jsonMatch[0] : output
-          expect(JSON.parse(jsonOutput)).toMatchObject(expectedJson.apis[0].value.apidoc)
+          const parsed = JSON.parse(jsonOutput)
+          // should include URL field built from gwApiUrl
+          expect(parsed).toBeInstanceOf(Array)
+          expect(parsed[0]).toHaveProperty('URL')
+          expect(parsed[0].URL).toContain(expectedJson.apis[0].value.gwApiUrl)
         })
         .finally(() => {
           stdout.stop()

--- a/test/commands/runtime/api/list.test.js
+++ b/test/commands/runtime/api/list.test.js
@@ -102,13 +102,17 @@ describe('instance methods', () => {
         .then(() => {
           const expectedJson = fixtureJson('api/list.json')
           const output = stdout.output.trim()
-          const jsonMatch = output.match(/\[[\s\S]*\]$/)
+          const jsonMatch = output.match(/\{[\s\S]*\}$/)
           const jsonOutput = jsonMatch ? jsonMatch[0] : output
           const parsed = JSON.parse(jsonOutput)
-          // should include URL field built from gwApiUrl
-          expect(parsed).toBeInstanceOf(Array)
-          expect(parsed[0]).toHaveProperty('URL')
-          expect(parsed[0].URL).toContain(expectedJson.apis[0].value.gwApiUrl)
+          const { apis } = expectedJson
+          const gwApiUrl = apis[0].value.gwApiUrl
+          // apidoc structure preserved
+          expect(parsed.basePath).toEqual(apis[0].value.apidoc.basePath)
+          expect(parsed.info).toMatchObject(apis[0].value.apidoc.info)
+          expect(parsed.swagger).toEqual(apis[0].value.apidoc.swagger)
+          // x-openwhisk.url updated with actual gateway URL (was "not-used")
+          expect(parsed.paths['/mypath'].get['x-openwhisk'].url).toEqual(`${gwApiUrl}/mypath`)
         })
         .finally(() => {
           stdout.stop()

--- a/test/commands/runtime/api/list.test.js
+++ b/test/commands/runtime/api/list.test.js
@@ -119,6 +119,44 @@ describe('instance methods', () => {
         })
     })
 
+    test('--json flag, operation without x-openwhisk leaves url unchanged', () => {
+      rtLib.mockResolved(rtAction, {
+        apis: [{
+          value: {
+            gwApiUrl: 'https://example.com/api',
+            apidoc: {
+              basePath: '/test',
+              info: { title: 'test', version: '1.0.0' },
+              swagger: '2.0',
+              paths: {
+                '/mypath': {
+                  get: {
+                    operationId: 'testOp',
+                    responses: { default: { description: 'Default response' } }
+                    // no x-openwhisk field
+                  }
+                }
+              }
+            }
+          }
+        }]
+      })
+      stdout.stop()
+      stdout.start()
+      const cmd = new TheCommand(['--json'])
+      return cmd.run()
+        .then(() => {
+          const output = stdout.output.trim()
+          const jsonMatch = output.match(/\{[\s\S]*\}$/)
+          const parsed = JSON.parse(jsonMatch ? jsonMatch[0] : output)
+          // operation without x-openwhisk should be left intact
+          expect(parsed.paths['/mypath'].get).not.toHaveProperty('x-openwhisk')
+        })
+        .finally(() => {
+          stdout.stop()
+        })
+    })
+
     test('error, throws exception', async () => {
       rtLib.mockRejected(rtAction, new Error('an error'))
       const error = ['failed to list the api', new Error('an error')]


### PR DESCRIPTION
Fixes #388 

## Summary
- Fixes #388 — `aio rt api list --json` was not showing the API URL
- The `--json` output preserves the existing `apidoc` JSON structure unchanged
- The `x-openwhisk.url` field (previously always `"not-used"`) is now populated with the actual gateway URL built from `gwApiUrl + path`

## Test plan
- [x] Run `npm test -- --testPathPattern="api/list"` — all tests pass
- [x] Verify `aio rt api list --json` output retains the `apidoc` structure with `x-openwhisk.url` now set to the real URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)