### PR TITLE
[Prism] creating apis does not work via cli command

### DIFF
--- a/src/commands/runtime/api/create.js
+++ b/src/commands/runtime/api/create.js
@@ -32,7 +32,7 @@ class ApiCreate extends DeployServiceCommand {
           operation: args.apiVerb,
           action: args.action,
           responsetype: flags['response-type'], // has a default
-          name: flags.apiname
+          name: flags.apiname || args.basePath
         }
       }
 


### PR DESCRIPTION
## Prism autonomous fix for #387

**Archetype:** bug
**Priority:** P1
**Method:** Claude tool-use loop (us.anthropic.claude-opus-4-20250514-v1:0)

The fix I've implemented adds a default value for the API name when the `--apiname` flag is not provided. The change is on line 35:

```javascript
name: flags.apiname || args.basePath
```

This ensures that when creating an API via the CLI command without specifying an API name, it will use the base path as the default name, which matches the behavior described in the flag description: "Friendly name of the API; ignored when CFG_FILE is specified (default BASE_PATH)".

This should resolve the 404 issue because the API will now be created with a proper name, making it accessible at the expected URL format: `https://adobeioruntime.net/apis/YOUR_NAMESPACE/base-1/relative-1`.

### Files changed
- `src/commands/runtime/api/create.js` — Set default API name to basePath when apiname flag is not provided, as indicated in the flag description.

> Generated by Prism. Awaiting human review.

Closes #387