### PR TITLE
Feat/ip list get

### DIFF
--- a/README.md
+++ b/README.md
@@ -2341,7 +2341,70 @@ ALIASES
 _See code: [src/commands/runtime/trigger/update.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/8.2.0/src/commands/runtime/trigger/update.js)_
 <!-- commandsstop -->
 
+### Using `aio runtime ip-list get` across multiple Adobe orgs
 
+The `aio runtime ip-list get` command returns the egress IP allowlist for whichever Adobe org you have selected via `aio console org select`. If you belong to multiple Adobe orgs and want to retrieve the list for a different one, switch the CLI's selected org first and then re-run the command:
+
+```bash
+aio console org select   # pick the target org
+aio runtime ip-list get
+```
+
+#### First-use terms acceptance
+
+The first time a given Adobe user runs the command against a given Adobe org, the service requires acceptance of the terms of use for that org and prompts for a contact email used for IP-change notifications:
+
+```bash
+aio runtime ip-list get
+# ? Accept terms v1? (Y/n)
+# ? Contact email (for IP-change notifications): you@example.com
+```
+
+For non-interactive contexts (CI, scripts, automation), supply the acceptance flag and a contact email directly:
+
+```bash
+aio runtime ip-list get --accept-terms --contact-email ops@example.com
+```
+
+Once acceptance is recorded for that (org, user) pair, subsequent calls are non-interactive and return the IP list immediately.
+
+#### Switching orgs
+
+Terms acceptance is stored per `(org, user)`. After accepting terms in org A, switching to org B will prompt for acceptance again the first time you call the command against org B. This is by design — each Adobe org accepts terms independently. After acceptance, you can flip back and forth between orgs without further prompts:
+
+```bash
+aio console org select       # pick org A
+aio runtime ip-list get      # first call against A: terms prompt, then IPs
+aio console org select       # pick org B
+aio runtime ip-list get      # first call against B: terms prompt, then IPs
+aio console org select       # back to A
+aio runtime ip-list get      # no prompt — IPs returned directly
+```
+
+#### If you previously ran `aio app use`
+
+`aio app use` writes an IMS org id binding to `project.org.ims_org_id` (in both the global aio config and a local `.aio` file in the project directory). That binding takes precedence over `aio console org select` for this command. To target a different org:
+
+```bash
+# Option 1 — rebind the project to a workspace in the new org:
+aio console org select          # new org
+aio console project select      # a project you belong to in that org
+aio console workspace select
+aio app use
+
+# Option 2 — drop the project binding entirely and use the console org selection:
+aio config delete project.org.ims_org_id
+# If a local .aio file exists in your current directory, also remove it
+# (or run the command from a different directory).
+```
+
+#### Common errors and how to resolve them
+
+| Symptom | Likely cause | Resolution |
+| --- | --- | --- |
+| `IMS org id not found in aio config.` | No org has been bound to the CLI. | Run `aio console org select` or `aio app use`. |
+| `ip-list service returned 403: token does not grant access to org X@AdobeOrg` | Your IMS token does not grant access to the org id the CLI is sending. Common after switching Adobe accounts. | Verify which org the CLI is using with `aio config get console.org.code` and `aio config get project.org.ims_org_id`; update whichever is stale (see "Switching orgs" above). |
+| Stuck on terms prompt in CI. | Non-interactive context cannot answer the prompt. | Re-run with `--accept-terms --contact-email <email>`. |
 
 ### Contributing
 

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -77,7 +77,7 @@ async function getAccessToken () {
 }
 
 /**
- * Resolve the caller's IMS organization id from local aio config, or
+ * Resolve the caller's IMS org id from local aio config, or
  * return null if no binding is configured. The service validates the
  * IMS token and checks that the claimed imsOrgId is one the token-holder
  * actually belongs to, so the caller fails fast on null rather than
@@ -90,18 +90,13 @@ async function getAccessToken () {
  */
 function resolveImsOrgId () {
   /*
-   * Key order matters and reflects what each `aio` flow actually writes:
-   *
    *   - `aio app use` writes the IMS org id to `project.org.ims_org_id`
    *     in the local project config (.aio / .env). When present this is
    *     the most specific binding — the user explicitly imported a
    *     workspace into the cwd — so we prefer it.
-   *   - `aio console org select` writes the IMS org id to
-   *     `console.org.code` (NOT `console.org.ims_org_id`, despite the
-   *     name). `console.org.id` next to it is the Console *numeric* org
-   *     id, which the ip-list service does not accept.
-   *   - `ims.org_id` is a legacy key kept for back-compat with very old
-   *     aio configs.
+   *   - `aio console org select` writes the IMS org id to `console.org.code`.
+   *   -  ip-list service does not accept`console.org.id` which is the amsOrgId
+   *   - `ims.org_id` is a legacy key kept for back-compat with very old aio configs.
    *
    * Returning null (rather than throwing) lets run() render a friendly,
    * stack-free message via this.error() above its try/catch.
@@ -132,7 +127,7 @@ function resolveImsOrgId () {
  * @param {string} opts.orgId - IMS org id (`<ident>@AdobeOrg`).
  * @param {Function} [opts.fetchImpl] - fetch override, used by tests.
  * @returns {Promise<{status: number, body: object|null, rawBody: string}>}
- *   response envelope.
+ *   response envelope
  */
 async function callService ({ host, path, body, token, orgId, fetchImpl }) {
   const f = fetchImpl || global.fetch
@@ -267,18 +262,6 @@ class IpListGet extends RuntimeBaseCommand {
    */
   async run () {
     const { flags } = await this.parse(IpListGet)
-
-    /*
-     * Cheap, deterministic precondition checks. These are expected
-     * user-input states — bad flag values, an unbound shell — not
-     * exceptions, so we call this.error() directly here instead of
-     * routing through RuntimeBaseCommand.handleError. handleError
-     * re-wraps and re-throws without setting `code`, which causes
-     * oclif to print the full stack trace; for a customer-facing
-     * command that's ugly and unhelpful. The try/catch below still
-     * funnels real exceptions (network, 5xx, JSON parse) through the
-     * shared error path so they look like the rest of the plugin.
-     */
     if (flags.region && !VALID_REGIONS.includes(flags.region)) {
       this.error(`invalid region "${flags.region}". Expected one of: ${VALID_REGIONS.join(', ')}`, { exit: 1 })
     }
@@ -290,7 +273,7 @@ class IpListGet extends RuntimeBaseCommand {
       this.error(
         'IMS org id not found in aio config.\n\n' +
         'Run one of the following and try again:\n' +
-        '  aio console org select\n' +
+        '  aio console org select\n' + 'or' +
         '  aio app use',
         { exit: 1 }
       )
@@ -365,9 +348,9 @@ class IpListGet extends RuntimeBaseCommand {
 
     if (!accepted) {
       /*
-       * Lazy-load inquirer so non-interactive runs (--accept-terms or
-       * pre-accepted users) don't pay the ESM-import cost. inquirer v9+
-       * is ESM-first and, when `require`d from a CommonJS caller, exposes
+       * Lazy-load inquirer so non-interactive runs like --accept-terms or
+       * pre-accepted users don't pay the ESM-import cost. inquirer v9+
+       * is ESM-first and, when `require`d from a CommonJS caller, it exposes
        * its public API on `.default`; v12 follows the same shape (see
        * `node -e 'console.log(Object.keys(require("inquirer")))'` →
        * `['createPromptModule','default']`).

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -78,10 +78,10 @@ async function getAccessToken () {
 
 /**
  * Resolve the caller's IMS organization id from local aio config. The
- * require-adobe-auth sequence keys the caller's org off the
- * x-gw-ims-org-id header we attach to every request, so if the CLI
- * has not been bound to an IMS org we fail fast rather than letting
- * the server return a confusing 401.
+ * service validates the IMS token and checks that the claimed imsOrgId
+ * is one the token-holder actually belongs to, so if the CLI has not
+ * been bound to an IMS org (i.e. no `aio console org select`) we fail
+ * fast rather than sending a request that would be rejected with 400.
  *
  * @returns {string} IMS org id in `...@AdobeOrg` form.
  * @throws {Error} if no org id has been configured.
@@ -105,29 +105,35 @@ function getImsOrgIdOrError () {
  * caller can present a useful message when the origin returns non-JSON
  * (e.g. the CloudFront 503 HTML page — tracked in ACNA-4547).
  *
+ * As of the cross-org refactor the service's web actions run with
+ * `require-adobe-auth: false` and perform their own IMS validation inside
+ * the action (see actions/auth.js in OneAdobe/ip-list-service). The
+ * canonical request shape is therefore POST + JSON body with `token` and
+ * `imsOrgId` carried *in the body* rather than in headers; the Authorization
+ * / x-gw-ims-org-id header shape is a deprecated fallback only still
+ * supported for backward compatibility.
+ *
  * @param {object} opts - Request options.
- * @param {string} opts.method - HTTP method.
  * @param {string} opts.host - ip-list service host.
  * @param {string} opts.path - Request path.
+ * @param {object} opts.body - JSON body; token + imsOrgId are merged in here.
  * @param {string} opts.token - IMS bearer token.
- * @param {string} opts.orgId - IMS org id (sent as x-gw-ims-org-id).
- * @param {object} [opts.body] - JSON body (omit for GET).
+ * @param {string} opts.orgId - IMS org id (`<ident>@AdobeOrg`).
  * @param {Function} [opts.fetchImpl] - fetch override, used by tests.
  * @returns {Promise<{status: number, body: object|null, rawBody: string}>}
  *   response envelope.
  */
-async function callService ({ method, host, path, token, orgId, body, fetchImpl }) {
+async function callService ({ host, path, body, token, orgId, fetchImpl }) {
   const f = fetchImpl || global.fetch
   const url = joinUrl(host, path)
-  const headers = {
-    Authorization: `Bearer ${token}`,
-    'x-gw-ims-org-id': orgId,
-    Accept: 'application/json'
-  }
-  const init = { method, headers }
-  if (body !== undefined) {
-    headers['Content-Type'] = 'application/json'
-    init.body = JSON.stringify(body)
+  const payload = { ...(body || {}), token, imsOrgId: orgId }
+  const init = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    },
+    body: JSON.stringify(payload)
   }
   const res = await f(url, init)
   const text = await res.text()
@@ -154,11 +160,12 @@ async function callService ({ method, host, path, token, orgId, body, fetchImpl 
  * @returns {Promise<object>} response envelope from {@link callService}.
  */
 async function getIpList ({ host, token, orgId, region, fetchImpl }) {
-  const query = region ? `?region=${encodeURIComponent(region)}&surface=${SURFACE}` : `?surface=${SURFACE}`
+  const body = { surface: SURFACE }
+  if (region) body.region = region
   return callService({
-    method: 'GET',
     host,
-    path: `${SERVICE_PATH}/get-ip-list${query}`,
+    path: `${SERVICE_PATH}/get-ip-list`,
+    body,
     token,
     orgId,
     fetchImpl
@@ -179,12 +186,11 @@ async function getIpList ({ host, token, orgId, region, fetchImpl }) {
  */
 async function postAcceptTerms ({ host, token, orgId, contactEmail, termsVersion, fetchImpl }) {
   return callService({
-    method: 'POST',
     host,
     path: `${SERVICE_PATH}/accept-terms`,
+    body: { contactEmail, termsVersion, surface: SURFACE },
     token,
     orgId,
-    body: { contactEmail, termsVersion, surface: SURFACE },
     fetchImpl
   })
 }

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -24,7 +24,7 @@ const { CLI } = require('@adobe/aio-lib-ims/src/context')
  * this command relies on. The runtime host preserves the original status
  * code and JSON body.
  */
-const DEFAULT_SERVICE_HOST = '53444-iplistservice-stage.adobeioruntime.net'
+const DEFAULT_SERVICE_HOST = '53444-iplistservice.adobeioruntime.net'
 const SERVICE_PATH = '/api/v1/web/ip-list'
 const SURFACE = 'cli'
 const VALID_REGIONS = ['amer', 'emea', 'apac', 'aus']

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -13,16 +13,6 @@ governing permissions and limitations under the License.
 const { Flags } = require('@oclif/core')
 const config = require('@adobe/aio-lib-core-config')
 const chalk = require('chalk')
-/*
- * inquirer v9+ is ESM-first and, when `require`d from a CommonJS caller,
- * surfaces its public API under a `.default` namespace instead of the
- * bare module.exports it used to in v8. We use `.default ?? module`
- * so this command keeps working against either shape — the fallback
- * matters for tests that mock `inquirer` with a plain `{ prompt: fn }`
- * object.
- */
-const inquirerMod = require('inquirer')
-const inquirer = inquirerMod.default || inquirerMod
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
 const { getToken, context } = require('@adobe/aio-lib-ims')
 const { CLI } = require('@adobe/aio-lib-ims/src/context')
@@ -34,6 +24,7 @@ const { CLI } = require('@adobe/aio-lib-ims/src/context')
  * clobber the 403 TERMS_REQUIRED flow this command depends on. Tracked as
  * ACNA-4547. The runtime host preserves the underlying status code + JSON
  * body and exercises the same require-adobe-auth sequence + IMS validation.
+ *
  */
 const DEFAULT_SERVICE_HOST = '53444-iplistservice-stage.adobeioruntime.net'
 const SERVICE_PATH = '/api/v1/web/ip-list'
@@ -86,26 +77,39 @@ async function getAccessToken () {
 }
 
 /**
- * Resolve the caller's IMS organization id from local aio config. The
- * service validates the IMS token and checks that the claimed imsOrgId
- * is one the token-holder actually belongs to, so if the CLI has not
- * been bound to an IMS org (i.e. no `aio console org select`) we fail
- * fast rather than sending a request that would be rejected with 400.
+ * Resolve the caller's IMS organization id from local aio config, or
+ * return null if no binding is configured. The service validates the
+ * IMS token and checks that the claimed imsOrgId is one the token-holder
+ * actually belongs to, so the caller fails fast on null rather than
+ * sending a request that would be rejected with 400. Returning null
+ * (instead of throwing) lets run() render a friendly, stack-free message
+ * via this.error() above the try/catch that routes real exceptions
+ * through RuntimeBaseCommand.handleError.
  *
- * @returns {string} IMS org id in `...@AdobeOrg` form.
- * @throws {Error} if no org id has been configured.
+ * @returns {string|null} IMS org id in `...@AdobeOrg` form, or null.
  */
-function getImsOrgIdOrError () {
-  const orgId = config.get('project.org.ims_org_id') ||
-    config.get('console.org.ims_org_id') ||
-    config.get('ims.org_id')
-  if (!orgId) {
-    throw new Error(
-      'IMS org id not found in aio config. Run `aio console org select` ' +
-      'or `aio app use` to bind this shell to an Adobe IMS org.'
-    )
-  }
-  return orgId
+function resolveImsOrgId () {
+  /*
+   * Key order matters and reflects what each `aio` flow actually writes:
+   *
+   *   - `aio app use` writes the IMS org id to `project.org.ims_org_id`
+   *     in the local project config (.aio / .env). When present this is
+   *     the most specific binding — the user explicitly imported a
+   *     workspace into the cwd — so we prefer it.
+   *   - `aio console org select` writes the IMS org id to
+   *     `console.org.code` (NOT `console.org.ims_org_id`, despite the
+   *     name). `console.org.id` next to it is the Console *numeric* org
+   *     id, which the ip-list service does not accept.
+   *   - `ims.org_id` is a legacy key kept for back-compat with very old
+   *     aio configs.
+   *
+   * Returning null (rather than throwing) lets run() render a friendly,
+   * stack-free message via this.error() above its try/catch.
+   */
+  return config.get('project.org.ims_org_id') ||
+    config.get('console.org.code') ||
+    config.get('ims.org_id') ||
+    null
 }
 
 /**
@@ -116,11 +120,9 @@ function getImsOrgIdOrError () {
  *
  * As of the cross-org refactor the service's web actions run with
  * `require-adobe-auth: false` and perform their own IMS validation inside
- * the action (see actions/auth.js in OneAdobe/ip-list-service). The
- * canonical request shape is therefore POST + JSON body with `token` and
- * `imsOrgId` carried *in the body* rather than in headers; the Authorization
- * / x-gw-ims-org-id header shape is a deprecated fallback only still
- * supported for backward compatibility.
+ * the action (see actions/auth.js in adobe-developer-platform/app-builder-ip-list-service).
+ * The canonical request shape is therefore POST + JSON body with `token`
+ * and `imsOrgId` carried *in the body* rather than in headers.
  *
  * @param {object} opts - Request options.
  * @param {string} opts.host - ip-list service host.
@@ -181,18 +183,6 @@ async function getIpList ({ host, token, orgId, region, fetchImpl }) {
   })
 }
 
-/**
- * POST a terms acceptance record for the current CLI user.
- *
- * @param {object} opts - request options.
- * @param {string} opts.host - ip-list service host.
- * @param {string} opts.token - IMS bearer token.
- * @param {string} opts.orgId - IMS org id.
- * @param {string} opts.contactEmail - email to record for notifications.
- * @param {number} opts.termsVersion - version the caller is accepting.
- * @param {Function} [opts.fetchImpl] - fetch override for tests.
- * @returns {Promise<object>} response envelope from {@link callService}.
- */
 /**
  * POST a terms acceptance record for the current CLI user.
  *
@@ -277,23 +267,44 @@ class IpListGet extends RuntimeBaseCommand {
    */
   async run () {
     const { flags } = await this.parse(IpListGet)
+
+    /*
+     * Cheap, deterministic precondition checks. These are expected
+     * user-input states — bad flag values, an unbound shell — not
+     * exceptions, so we call this.error() directly here instead of
+     * routing through RuntimeBaseCommand.handleError. handleError
+     * re-wraps and re-throws without setting `code`, which causes
+     * oclif to print the full stack trace; for a customer-facing
+     * command that's ugly and unhelpful. The try/catch below still
+     * funnels real exceptions (network, 5xx, JSON parse) through the
+     * shared error path so they look like the rest of the plugin.
+     */
+    if (flags.region && !VALID_REGIONS.includes(flags.region)) {
+      this.error(`invalid region "${flags.region}". Expected one of: ${VALID_REGIONS.join(', ')}`, { exit: 1 })
+    }
+    if (flags['accept-terms'] && !flags['contact-email']) {
+      this.error('--accept-terms requires --contact-email', { exit: 1 })
+    }
+    const orgId = resolveImsOrgId()
+    if (!orgId) {
+      this.error(
+        'IMS org id not found in aio config.\n\n' +
+        'Run one of the following and try again:\n' +
+        '  aio console org select\n' +
+        '  aio app use',
+        { exit: 1 }
+      )
+    }
+
     try {
-      await this.runPipeline(flags)
+      await this.runPipeline(flags, orgId)
     } catch (err) {
       await this.handleError('failed to fetch the egress IP list', err)
     }
   }
 
-  async runPipeline (flags) {
-    if (flags.region && !VALID_REGIONS.includes(flags.region)) {
-      this.error(`invalid region "${flags.region}". Expected one of: ${VALID_REGIONS.join(', ')}`)
-    }
-    if (flags['accept-terms'] && !flags['contact-email']) {
-      this.error('--accept-terms requires --contact-email')
-    }
-
+  async runPipeline (flags, orgId) {
     const host = resolveHost(flags)
-    const orgId = getImsOrgIdOrError()
     const token = await getAccessToken()
 
     // First attempt. Most repeat callers already have terms accepted
@@ -324,13 +335,21 @@ class IpListGet extends RuntimeBaseCommand {
   async handleTermsRequired ({ flags, res, host, token, orgId }) {
     const { termsText, termsUrl, termsVersion } = res.body
 
-    this.log('')
-    this.log(chalk.yellow.bold('This service requires terms acceptance before first use.'))
-    if (termsUrl) this.log(chalk.dim(`Full terms: ${termsUrl}`))
-    this.log('')
+    /*
+     * Informational output goes to stderr so that `--json` consumers get
+     * clean, parseable JSON on stdout even on the first-use path (where
+     * the terms text, prompt, and "accepted" notice would otherwise be
+     * interleaved with the eventual JSON payload).
+     */
+    const info = (msg) => process.stderr.write(msg + '\n')
+
+    info('')
+    info(chalk.yellow.bold('This service requires terms acceptance before first use.'))
+    if (termsUrl) info(chalk.dim(`Full terms: ${termsUrl}`))
+    info('')
     if (termsText) {
-      this.log(termsText)
-      this.log('')
+      info(termsText)
+      info('')
     }
 
     let contactEmail = flags['contact-email']
@@ -346,11 +365,14 @@ class IpListGet extends RuntimeBaseCommand {
 
     if (!accepted) {
       /*
-       * istanbul ignore next -- interactive branch; exercised in manual
-       * demo runs. Unit tests route through --accept-terms to keep the
-       * test path deterministic, matching the way aio-cli-plugin-runtime
-       * tests its other inquirer-backed flows.
+       * Lazy-load inquirer so non-interactive runs (--accept-terms or
+       * pre-accepted users) don't pay the ESM-import cost. inquirer v9+
+       * is ESM-first and, when `require`d from a CommonJS caller, exposes
+       * its public API on `.default`; v12 follows the same shape (see
+       * `node -e 'console.log(Object.keys(require("inquirer")))'` →
+       * `['createPromptModule','default']`).
        */
+      const inquirer = require('inquirer').default
       const answers = await inquirer.prompt([
         { name: 'accept', type: 'confirm', message: `Accept terms v${termsVersion}?`, default: false },
         {
@@ -380,12 +402,24 @@ class IpListGet extends RuntimeBaseCommand {
         acceptRes.rawBody || `http ${acceptRes.status}`
       this.error(`failed to record terms acceptance (${acceptRes.status}): ${detail}`)
     }
-    this.log(chalk.green(`Terms v${termsVersion} accepted. Fetching the IP list...`))
+    info(chalk.green(`Terms v${termsVersion} accepted. Fetching the IP list...`))
   }
 }
 
+/*
+ * Flags. This command does not talk to OpenWhisk, so it deliberately does
+ * NOT spread `RuntimeBaseCommand.flags` — that would expose --apihost,
+ * --auth, --cert, --key, --insecure, which would be silently ignored here
+ * and confusing in `--help`. We inherit only --debug / --verbose so the
+ * standard plugin-wide logging knobs still work.
+ *
+ * --service-host is a `hidden: true` escape hatch for stage / manual
+ * testing, not a customer-supported endpoint override (see AIO_IP_LIST_HOST
+ * env var for test validation).
+ */
 IpListGet.flags = {
-  ...RuntimeBaseCommand.flags,
+  debug: RuntimeBaseCommand.flags.debug,
+  verbose: RuntimeBaseCommand.flags.verbose,
   region: Flags.string({
     description: `restrict output to one region (${VALID_REGIONS.join(', ')})`
   }),
@@ -396,7 +430,8 @@ IpListGet.flags = {
     description: 'contact email used when accepting terms and subscribing to change notifications'
   }),
   'service-host': Flags.string({
-    description: 'override the ip-list service host (also: AIO_IP_LIST_HOST env var)'
+    hidden: true,
+    description: 'override the ip-list service host (escape hatch; also AIO_IP_LIST_HOST env var)'
   }),
   json: Flags.boolean({
     description: 'output raw JSON instead of a formatted table'

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -18,13 +18,11 @@ const { getToken, context } = require('@adobe/aio-lib-ims')
 const { CLI } = require('@adobe/aio-lib-ims/src/context')
 
 /*
- * Service endpoint. Hits the runtime host directly (NOT adobeio-static.net)
- * because the CloudFront distribution in front of the static host rewrites
- * every non-2xx origin response as a generic 503 HTML page, which would
- * clobber the 403 TERMS_REQUIRED flow this command depends on. Tracked as
- * ACNA-4547. The runtime host preserves the underlying status code + JSON
- * body and exercises the same require-adobe-auth sequence + IMS validation.
- *
+ * Service endpoint. Targets the runtime host directly rather than the CDN
+ * fronted by adobeio-static.net: the CDN rewrites non-2xx origin responses
+ * as a generic 503 HTML page, which masks the 403 TERMS_REQUIRED envelope
+ * this command relies on. The runtime host preserves the original status
+ * code and JSON body.
  */
 const DEFAULT_SERVICE_HOST = '53444-iplistservice-stage.adobeioruntime.net'
 const SERVICE_PATH = '/api/v1/web/ip-list'
@@ -58,12 +56,11 @@ function joinUrl (host, path) {
 }
 
 /**
- * Pull an IMS access token for the current CLI context. Mirrors the
- * DeployServiceCommand.getAccessToken implementation so callers of this
- * command behave identically to `aio app deploy` w.r.t. token selection
- * (CLI context if none set, otherwise whatever the user context is).
+ * Resolve an IMS access token for the current CLI context. Uses the
+ * active IMS context if one is set; otherwise falls back to the bare
+ * CLI context, matching how `aio app deploy` selects its token.
  *
- * @returns {Promise<string>} bearer token suitable for the Authorization header.
+ * @returns {Promise<string>} Bearer token for the Authorization header.
  */
 async function getAccessToken () {
   let contextName = CLI
@@ -77,30 +74,23 @@ async function getAccessToken () {
 }
 
 /**
- * Resolve the caller's IMS org id from local aio config, or
- * return null if no binding is configured. The service validates the
- * IMS token and checks that the claimed imsOrgId is one the token-holder
- * actually belongs to, so the caller fails fast on null rather than
- * sending a request that would be rejected with 400. Returning null
- * (instead of throwing) lets run() render a friendly, stack-free message
- * via this.error() above the try/catch that routes real exceptions
- * through RuntimeBaseCommand.handleError.
+ * Resolve the caller's IMS org id from local aio config, or null if no
+ * binding is configured. The service validates the IMS token against
+ * the claimed imsOrgId and rejects mismatches with 400, so an unbound
+ * shell must short-circuit before any network call.
+ *
+ * Key precedence reflects what each aio flow actually writes:
+ *   - `project.org.ims_org_id` — populated by `aio app use` in the
+ *     local project config; most specific binding.
+ *   - `console.org.code` — populated by `aio console org select`. Note
+ *     this is the `@AdobeOrg` value despite the field name; the sibling
+ *     `console.org.id` is the Developer Console numeric id, which the
+ *     service does not accept.
+ *   - `ims.org_id` — legacy key retained for back-compat.
  *
  * @returns {string|null} IMS org id in `...@AdobeOrg` form, or null.
  */
 function resolveImsOrgId () {
-  /*
-   *   - `aio app use` writes the IMS org id to `project.org.ims_org_id`
-   *     in the local project config (.aio / .env). When present this is
-   *     the most specific binding — the user explicitly imported a
-   *     workspace into the cwd — so we prefer it.
-   *   - `aio console org select` writes the IMS org id to `console.org.code`.
-   *   -  ip-list service does not accept`console.org.id` which is the amsOrgId
-   *   - `ims.org_id` is a legacy key kept for back-compat with very old aio configs.
-   *
-   * Returning null (rather than throwing) lets run() render a friendly,
-   * stack-free message via this.error() above its try/catch.
-   */
   return config.get('project.org.ims_org_id') ||
     config.get('console.org.code') ||
     config.get('ims.org_id') ||
@@ -108,26 +98,25 @@ function resolveImsOrgId () {
 }
 
 /**
- * Low-level HTTP helper for the ip-list service. Returns both the parsed
- * JSON body (when the response decodes as JSON) and the raw text so the
- * caller can present a useful message when the origin returns non-JSON
- * (e.g. the CloudFront 503 HTML page — tracked in ACNA-4547).
+ * Low-level HTTP helper for the ip-list service. Returns the parsed JSON
+ * body when the response decodes as JSON, plus the raw text so callers
+ * can render a useful message when the origin returns non-JSON content.
  *
- * As of the cross-org refactor the service's web actions run with
- * `require-adobe-auth: false` and perform their own IMS validation inside
- * the action (see actions/auth.js in adobe-developer-platform/app-builder-ip-list-service).
- * The canonical request shape is therefore POST + JSON body with `token`
- * and `imsOrgId` carried *in the body* rather than in headers.
+ * The service's web actions perform IMS validation inside the action
+ * rather than at the gateway, so the canonical request shape is POST
+ * with `token` and `imsOrgId` carried in the JSON body rather than in
+ * Authorization / x-gw-ims-org-id headers.
  *
  * @param {object} opts - Request options.
- * @param {string} opts.host - ip-list service host.
+ * @param {string} opts.host - Service host.
  * @param {string} opts.path - Request path.
- * @param {object} opts.body - JSON body; token + imsOrgId are merged in here.
+ * @param {object} opts.body - JSON body; `token` and `imsOrgId` are merged in.
  * @param {string} opts.token - IMS bearer token.
  * @param {string} opts.orgId - IMS org id (`<ident>@AdobeOrg`).
- * @param {Function} [opts.fetchImpl] - fetch override, used by tests.
+ * @param {Function} [opts.fetchImpl] - Fetch override; used by tests.
  * @returns {Promise<{status: number, body: object|null, rawBody: string}>}
- *   response envelope
+ *   Response envelope with HTTP status, parsed JSON body (or null when
+ *   the response is not valid JSON), and the raw response text.
  */
 async function callService ({ host, path, body, token, orgId, fetchImpl }) {
   const f = fetchImpl || global.fetch
@@ -181,24 +170,21 @@ async function getIpList ({ host, token, orgId, region, fetchImpl }) {
 /**
  * POST a terms acceptance record for the current CLI user.
  *
- * `acceptanceMode` distinguishes whether the user saw + confirmed the
- * terms at an interactive prompt ("interactive") or passed the
- * `--accept-terms` flag non-interactively from a script / CI
- * ("programmatic"). The admin dashboard uses this signal to help
- * customer-support triage contacts: a human-attested acceptance is a
- * stronger audit signal than a flag-driven one.
+ * `acceptanceMode` records whether the user confirmed at an interactive
+ * prompt ("interactive") or passed `--accept-terms` non-interactively
+ * ("programmatic"). The server validates this against its allowlist and
+ * rejects anything else with 400.
  *
- * @param {object} opts - request options.
- * @param {string} opts.host - ip-list service host.
+ * @param {object} opts - Request options.
+ * @param {string} opts.host - Service host.
  * @param {string} opts.token - IMS bearer token.
  * @param {string} opts.orgId - IMS org id.
- * @param {string} opts.contactEmail - email to record for notifications.
- * @param {number} opts.termsVersion - version the caller is accepting.
- * @param {'interactive'|'programmatic'} opts.acceptanceMode - how the
- *   user expressed consent. The server validates this against its own
- *   whitelist and rejects anything else with 400.
- * @param {Function} [opts.fetchImpl] - fetch override for tests.
- * @returns {Promise<object>} response envelope from {@link callService}.
+ * @param {string} opts.contactEmail - Email recorded for change notifications.
+ * @param {number} opts.termsVersion - Version being accepted.
+ * @param {'interactive'|'programmatic'} opts.acceptanceMode - How the
+ *   user expressed consent.
+ * @param {Function} [opts.fetchImpl] - Fetch override; used by tests.
+ * @returns {Promise<object>} Response envelope from {@link callService}.
  */
 async function postAcceptTerms ({ host, token, orgId, contactEmail, termsVersion, acceptanceMode, fetchImpl }) {
   return callService({
@@ -213,11 +199,10 @@ async function postAcceptTerms ({ host, token, orgId, contactEmail, termsVersion
 
 /**
  * Render the ip-list service response as a terminal-friendly block
- * grouped by region. Mirrors the spirit of `runtime:namespace:get` but
- * with a simpler layout since there are only ever a handful of rows.
+ * grouped by region.
  *
- * @param {object} data - response body from `get-ip-list`.
- * @returns {string} text ready to pass to `this.log()`.
+ * @param {object} data - Response body from `get-ip-list`.
+ * @returns {string} Text ready to pass to `this.log()`.
  */
 function formatHumanOutput (data) {
   const lines = []
@@ -236,12 +221,8 @@ function formatHumanOutput (data) {
   }
   const longest = regionKeys.reduce((m, r) => Math.max(m, r.length), 0)
   for (const region of regionKeys) {
-    /*
-     * The service returns regions as { [region]: string[] }, a flat
-     * array of CIDR strings. We also tolerate a legacy { cidrs: [] }
-     * shape in case the payload ever gets re-enveloped — no other
-     * client has to care about the difference.
-     */
+    // Current wire shape is { [region]: string[] }; the legacy
+    // { cidrs: string[] } envelope is tolerated for forward-compatibility.
     const raw = regions[region]
     const cidrList = Array.isArray(raw) ? raw : (raw && raw.cidrs) || []
     const cidrs = [...cidrList].sort()
@@ -255,11 +236,9 @@ function formatHumanOutput (data) {
 }
 
 class IpListGet extends RuntimeBaseCommand {
-  /*
-   * NOTE: deliberately does not call super.run() / this.wsk() — this
-   * command doesn't talk to OpenWhisk directly. It hits the ip-list
-   * service HTTPS endpoint with an IMS bearer token.
-   */
+  // This command does not invoke OpenWhisk; it calls the ip-list HTTPS
+  // service with an IMS bearer token, so it does not call super.run()
+  // or this.wsk().
   async run () {
     const { flags } = await this.parse(IpListGet)
     if (flags.region && !VALID_REGIONS.includes(flags.region)) {
@@ -273,7 +252,7 @@ class IpListGet extends RuntimeBaseCommand {
       this.error(
         'IMS org id not found in aio config.\n\n' +
         'Run one of the following and try again:\n' +
-        '  aio console org select\n' + 'or' +
+        '  aio console org select\n' +
         '  aio app use',
         { exit: 1 }
       )
@@ -290,13 +269,13 @@ class IpListGet extends RuntimeBaseCommand {
     const host = resolveHost(flags)
     const token = await getAccessToken()
 
-    // First attempt. Most repeat callers already have terms accepted
-    // for their (org, user, surface) tuple and get 200 on the first try.
+    // Repeat callers with an existing acceptance record for their
+    // (org, user, surface) tuple receive 200 on the first attempt.
     let res = await getIpList({ host, token, orgId, region: flags.region })
 
     if (res.status === 403 && res.body && res.body.error === 'TERMS_REQUIRED') {
       await this.handleTermsRequired({ flags, res, host, token, orgId })
-      // Retry once after acceptance.
+      // Retry once after recording acceptance.
       res = await getIpList({ host, token, orgId, region: flags.region })
       if (res.status === 403 && res.body && res.body.error === 'TERMS_REQUIRED') {
         this.error('terms were not accepted; try again with --accept-terms --contact-email you@example.com')
@@ -318,12 +297,10 @@ class IpListGet extends RuntimeBaseCommand {
   async handleTermsRequired ({ flags, res, host, token, orgId }) {
     const { termsText, termsUrl, termsVersion } = res.body
 
-    /*
-     * Informational output goes to stderr so that `--json` consumers get
-     * clean, parseable JSON on stdout even on the first-use path (where
-     * the terms text, prompt, and "accepted" notice would otherwise be
-     * interleaved with the eventual JSON payload).
-     */
+    // Informational output is written to stderr so `--json` consumers
+    // receive only the JSON payload on stdout, even on the first-use
+    // path where the terms text and acceptance notice would otherwise
+    // be interleaved with the response body.
     const info = (msg) => process.stderr.write(msg + '\n')
 
     info('')
@@ -337,24 +314,16 @@ class IpListGet extends RuntimeBaseCommand {
 
     let contactEmail = flags['contact-email']
     let accepted = flags['accept-terms']
-    /*
-     * If --accept-terms was passed on the command line we never hit the
-     * inquirer branch, so the acceptance is by definition programmatic.
-     * Capture the decision up front rather than inferring it later —
-     * this mirrors what the server stores and keeps the two code paths
-     * symmetric.
-     */
+    // Captured up front so the value the server records matches the
+    // path actually taken: `--accept-terms` is always "programmatic",
+    // interactive prompt confirmations are "interactive".
     const acceptanceMode = accepted ? 'programmatic' : 'interactive'
 
     if (!accepted) {
-      /*
-       * Lazy-load inquirer so non-interactive runs like --accept-terms or
-       * pre-accepted users don't pay the ESM-import cost. inquirer v9+
-       * is ESM-first and, when `require`d from a CommonJS caller, it exposes
-       * its public API on `.default`; v12 follows the same shape (see
-       * `node -e 'console.log(Object.keys(require("inquirer")))'` →
-       * `['createPromptModule','default']`).
-       */
+      // Lazy-required so non-interactive runs (`--accept-terms` or
+      // already-accepted users) do not pay the ESM-import cost.
+      // inquirer v9+ is ESM-first; when required from a CommonJS
+      // caller, its public API is exposed on `.default`.
       const inquirer = require('inquirer').default
       const answers = await inquirer.prompt([
         { name: 'accept', type: 'confirm', message: `Accept terms v${termsVersion}?`, default: false },
@@ -390,15 +359,14 @@ class IpListGet extends RuntimeBaseCommand {
 }
 
 /*
- * Flags. This command does not talk to OpenWhisk, so it deliberately does
- * NOT spread `RuntimeBaseCommand.flags` — that would expose --apihost,
- * --auth, --cert, --key, --insecure, which would be silently ignored here
- * and confusing in `--help`. We inherit only --debug / --verbose so the
- * standard plugin-wide logging knobs still work.
+ * This command does not call OpenWhisk, so the OpenWhisk-targeted flags
+ * from RuntimeBaseCommand (--apihost, --auth, --cert, --key, --insecure)
+ * are intentionally excluded — they would be silently ignored and noisy
+ * in --help. Only --debug and --verbose are inherited.
  *
- * --service-host is a `hidden: true` escape hatch for stage / manual
- * testing, not a customer-supported endpoint override (see AIO_IP_LIST_HOST
- * env var for test validation).
+ * --service-host is hidden because it is an internal escape hatch for
+ * stage testing, not a customer-supported endpoint override. The
+ * equivalent AIO_IP_LIST_HOST env var is available for the same purpose.
  */
 IpListGet.flags = {
   debug: RuntimeBaseCommand.flags.debug,
@@ -421,7 +389,7 @@ IpListGet.flags = {
   })
 }
 
-IpListGet.description = 'Fetch the current Adobe I/O Runtime egress IP allowlist (IMS-authenticated).\n' +
+IpListGet.description = 'Fetch the current Adobe I/O Runtime egress IP allowlist.\n' +
   'On first use the service returns the terms of service and the command prompts for acceptance; ' +
   'pass --accept-terms --contact-email to do that non-interactively.'
 

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -193,11 +193,33 @@ async function getIpList ({ host, token, orgId, region, fetchImpl }) {
  * @param {Function} [opts.fetchImpl] - fetch override for tests.
  * @returns {Promise<object>} response envelope from {@link callService}.
  */
-async function postAcceptTerms ({ host, token, orgId, contactEmail, termsVersion, fetchImpl }) {
+/**
+ * POST a terms acceptance record for the current CLI user.
+ *
+ * `acceptanceMode` distinguishes whether the user saw + confirmed the
+ * terms at an interactive prompt ("interactive") or passed the
+ * `--accept-terms` flag non-interactively from a script / CI
+ * ("programmatic"). The admin dashboard uses this signal to help
+ * customer-support triage contacts: a human-attested acceptance is a
+ * stronger audit signal than a flag-driven one.
+ *
+ * @param {object} opts - request options.
+ * @param {string} opts.host - ip-list service host.
+ * @param {string} opts.token - IMS bearer token.
+ * @param {string} opts.orgId - IMS org id.
+ * @param {string} opts.contactEmail - email to record for notifications.
+ * @param {number} opts.termsVersion - version the caller is accepting.
+ * @param {'interactive'|'programmatic'} opts.acceptanceMode - how the
+ *   user expressed consent. The server validates this against its own
+ *   whitelist and rejects anything else with 400.
+ * @param {Function} [opts.fetchImpl] - fetch override for tests.
+ * @returns {Promise<object>} response envelope from {@link callService}.
+ */
+async function postAcceptTerms ({ host, token, orgId, contactEmail, termsVersion, acceptanceMode, fetchImpl }) {
   return callService({
     host,
     path: `${SERVICE_PATH}/accept-terms`,
-    body: { contactEmail, termsVersion, surface: SURFACE },
+    body: { contactEmail, termsVersion, surface: SURFACE, acceptanceMode },
     token,
     orgId,
     fetchImpl
@@ -313,6 +335,14 @@ class IpListGet extends RuntimeBaseCommand {
 
     let contactEmail = flags['contact-email']
     let accepted = flags['accept-terms']
+    /*
+     * If --accept-terms was passed on the command line we never hit the
+     * inquirer branch, so the acceptance is by definition programmatic.
+     * Capture the decision up front rather than inferring it later —
+     * this mirrors what the server stores and keeps the two code paths
+     * symmetric.
+     */
+    const acceptanceMode = accepted ? 'programmatic' : 'interactive'
 
     if (!accepted) {
       /*
@@ -343,7 +373,7 @@ class IpListGet extends RuntimeBaseCommand {
     }
 
     const acceptRes = await postAcceptTerms({
-      host, token, orgId, contactEmail, termsVersion
+      host, token, orgId, contactEmail, termsVersion, acceptanceMode
     })
     if (acceptRes.status !== 200 && acceptRes.status !== 201) {
       const detail = (acceptRes.body && (acceptRes.body.error || acceptRes.body.message)) ||

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -43,19 +43,6 @@ function resolveHost (flags) {
 }
 
 /**
- * Build a canonical HTTPS URL from a host and path, stripping any scheme
- * / trailing slashes the caller may have supplied on the host.
- *
- * @param {string} host - Hostname, with or without protocol / trailing slash.
- * @param {string} path - Request path starting with `/`.
- * @returns {string} Fully-qualified `https://` URL.
- */
-function joinUrl (host, path) {
-  const cleanHost = host.replace(/^https?:\/\//, '').replace(/\/+$/, '')
-  return `https://${cleanHost}${path}`
-}
-
-/**
  * Resolve an IMS access token for the current CLI context. Uses the
  * active IMS context if one is set; otherwise falls back to the bare
  * CLI context, matching how `aio app deploy` selects its token.
@@ -120,7 +107,10 @@ function resolveImsOrgId () {
  */
 async function callService ({ host, path, body, token, orgId, fetchImpl }) {
   const f = fetchImpl || global.fetch
-  const url = joinUrl(host, path)
+  // Normalize the host: tolerate a scheme prefix or trailing slashes so
+  // callers can pass either `host.example.com` or `https://host.example.com/`.
+  const cleanHost = host.replace(/^https?:\/\//, '').replace(/\/+$/, '')
+  const url = `https://${cleanHost}${path}`
   const payload = { ...(body || {}), token, imsOrgId: orgId }
   const init = {
     method: 'POST',

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -1,0 +1,377 @@
+/*
+Copyright 2026 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Flags } = require('@oclif/core')
+const config = require('@adobe/aio-lib-core-config')
+const chalk = require('chalk')
+const inquirer = require('inquirer')
+const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
+const { getToken, context } = require('@adobe/aio-lib-ims')
+const { CLI } = require('@adobe/aio-lib-ims/src/context')
+
+/*
+ * Service endpoint. Hits the runtime host directly (NOT adobeio-static.net)
+ * because the CloudFront distribution in front of the static host rewrites
+ * every non-2xx origin response as a generic 503 HTML page, which would
+ * clobber the 403 TERMS_REQUIRED flow this command depends on. Tracked as
+ * ACNA-4547. The runtime host preserves the underlying status code + JSON
+ * body and exercises the same require-adobe-auth sequence + IMS validation.
+ */
+const DEFAULT_SERVICE_HOST = '53444-iplistservice-stage.adobeioruntime.net'
+const SERVICE_PATH = '/api/v1/web/ip-list'
+const SURFACE = 'cli'
+const VALID_REGIONS = ['amer', 'emea', 'apac', 'aus']
+
+/**
+ * Resolve the ip-list service host, preferring explicit flags, then env
+ * overrides, then the compiled-in default.
+ *
+ * @param {object} flags - Parsed oclif flags for this command.
+ * @returns {string} Host to target (without scheme, trailing slash, or path).
+ */
+function resolveHost (flags) {
+  return flags['service-host'] ||
+    process.env.AIO_IP_LIST_HOST ||
+    DEFAULT_SERVICE_HOST
+}
+
+/**
+ * Build a canonical HTTPS URL from a host and path, stripping any scheme
+ * / trailing slashes the caller may have supplied on the host.
+ *
+ * @param {string} host - Hostname, with or without protocol / trailing slash.
+ * @param {string} path - Request path starting with `/`.
+ * @returns {string} Fully-qualified `https://` URL.
+ */
+function joinUrl (host, path) {
+  const cleanHost = host.replace(/^https?:\/\//, '').replace(/\/+$/, '')
+  return `https://${cleanHost}${path}`
+}
+
+/**
+ * Pull an IMS access token for the current CLI context. Mirrors the
+ * DeployServiceCommand.getAccessToken implementation so callers of this
+ * command behave identically to `aio app deploy` w.r.t. token selection
+ * (CLI context if none set, otherwise whatever the user context is).
+ *
+ * @returns {Promise<string>} bearer token suitable for the Authorization header.
+ */
+async function getAccessToken () {
+  let contextName = CLI
+  const currentContext = await context.getCurrent()
+  if (currentContext && currentContext !== CLI) {
+    contextName = currentContext
+  } else {
+    await context.setCli({ 'cli.bare-output': true }, false)
+  }
+  return getToken(contextName)
+}
+
+/**
+ * Resolve the caller's IMS organization id from local aio config. The
+ * require-adobe-auth sequence keys the caller's org off the
+ * x-gw-ims-org-id header we attach to every request, so if the CLI
+ * has not been bound to an IMS org we fail fast rather than letting
+ * the server return a confusing 401.
+ *
+ * @returns {string} IMS org id in `...@AdobeOrg` form.
+ * @throws {Error} if no org id has been configured.
+ */
+function getImsOrgIdOrError () {
+  const orgId = config.get('project.org.ims_org_id') ||
+    config.get('console.org.ims_org_id') ||
+    config.get('ims.org_id')
+  if (!orgId) {
+    throw new Error(
+      'IMS org id not found in aio config. Run `aio console org select` ' +
+      'or `aio app use` to bind this shell to an Adobe IMS org.'
+    )
+  }
+  return orgId
+}
+
+/**
+ * Low-level HTTP helper for the ip-list service. Returns both the parsed
+ * JSON body (when the response decodes as JSON) and the raw text so the
+ * caller can present a useful message when the origin returns non-JSON
+ * (e.g. the CloudFront 503 HTML page — tracked in ACNA-4547).
+ *
+ * @param {object} opts - Request options.
+ * @param {string} opts.method - HTTP method.
+ * @param {string} opts.host - ip-list service host.
+ * @param {string} opts.path - Request path.
+ * @param {string} opts.token - IMS bearer token.
+ * @param {string} opts.orgId - IMS org id (sent as x-gw-ims-org-id).
+ * @param {object} [opts.body] - JSON body (omit for GET).
+ * @param {Function} [opts.fetchImpl] - fetch override, used by tests.
+ * @returns {Promise<{status: number, body: object|null, rawBody: string}>}
+ *   response envelope.
+ */
+async function callService ({ method, host, path, token, orgId, body, fetchImpl }) {
+  const f = fetchImpl || global.fetch
+  const url = joinUrl(host, path)
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'x-gw-ims-org-id': orgId,
+    Accept: 'application/json'
+  }
+  const init = { method, headers }
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json'
+    init.body = JSON.stringify(body)
+  }
+  const res = await f(url, init)
+  const text = await res.text()
+  let parsed = null
+  if (text) {
+    try {
+      parsed = JSON.parse(text)
+    } catch (_) {
+      /* leave parsed=null and let caller handle as raw */
+    }
+  }
+  return { status: res.status, body: parsed, rawBody: text }
+}
+
+/**
+ * Fetch the egress IP list, optionally scoped to a single region.
+ *
+ * @param {object} opts - see {@link callService}; adds `region`.
+ * @param {string} opts.host - ip-list service host.
+ * @param {string} opts.token - IMS bearer token.
+ * @param {string} opts.orgId - IMS org id.
+ * @param {string} [opts.region] - one of VALID_REGIONS.
+ * @param {Function} [opts.fetchImpl] - fetch override for tests.
+ * @returns {Promise<object>} response envelope from {@link callService}.
+ */
+async function getIpList ({ host, token, orgId, region, fetchImpl }) {
+  const query = region ? `?region=${encodeURIComponent(region)}&surface=${SURFACE}` : `?surface=${SURFACE}`
+  return callService({
+    method: 'GET',
+    host,
+    path: `${SERVICE_PATH}/get-ip-list${query}`,
+    token,
+    orgId,
+    fetchImpl
+  })
+}
+
+/**
+ * POST a terms acceptance record for the current CLI user.
+ *
+ * @param {object} opts - request options.
+ * @param {string} opts.host - ip-list service host.
+ * @param {string} opts.token - IMS bearer token.
+ * @param {string} opts.orgId - IMS org id.
+ * @param {string} opts.contactEmail - email to record for notifications.
+ * @param {number} opts.termsVersion - version the caller is accepting.
+ * @param {Function} [opts.fetchImpl] - fetch override for tests.
+ * @returns {Promise<object>} response envelope from {@link callService}.
+ */
+async function postAcceptTerms ({ host, token, orgId, contactEmail, termsVersion, fetchImpl }) {
+  return callService({
+    method: 'POST',
+    host,
+    path: `${SERVICE_PATH}/accept-terms`,
+    token,
+    orgId,
+    body: { contactEmail, termsVersion, surface: SURFACE },
+    fetchImpl
+  })
+}
+
+/**
+ * Render the ip-list service response as a terminal-friendly block
+ * grouped by region. Mirrors the spirit of `runtime:namespace:get` but
+ * with a simpler layout since there are only ever a handful of rows.
+ *
+ * @param {object} data - response body from `get-ip-list`.
+ * @returns {string} text ready to pass to `this.log()`.
+ */
+function formatHumanOutput (data) {
+  const lines = []
+  lines.push(chalk.bold('Adobe I/O Runtime egress IPs'))
+  lines.push(`  version:     ${data.version}`)
+  lines.push(`  lastUpdated: ${data.lastUpdated}`)
+  if (data.terms) {
+    lines.push(`  terms:       v${data.terms.version} accepted ${data.terms.acceptedAt}`)
+  }
+  lines.push('')
+  const regions = data.regions || {}
+  const regionKeys = Object.keys(regions).sort()
+  if (regionKeys.length === 0) {
+    lines.push(chalk.yellow('(no regions populated yet — the service has not been seeded)'))
+    return lines.join('\n')
+  }
+  const longest = regionKeys.reduce((m, r) => Math.max(m, r.length), 0)
+  for (const region of regionKeys) {
+    const cidrs = [...(regions[region].cidrs || [])].sort()
+    lines.push(chalk.bold(region.toUpperCase().padEnd(longest + 2)) + `(${cidrs.length} CIDR${cidrs.length === 1 ? '' : 's'})`)
+    for (const cidr of cidrs) {
+      lines.push(`  ${cidr}`)
+    }
+    lines.push('')
+  }
+  return lines.join('\n').replace(/\n+$/, '')
+}
+
+class IpListGet extends RuntimeBaseCommand {
+  /*
+   * NOTE: deliberately does not call super.run() / this.wsk() — this
+   * command doesn't talk to OpenWhisk directly. It hits the ip-list
+   * service HTTPS endpoint with an IMS bearer token.
+   */
+  async run () {
+    const { flags } = await this.parse(IpListGet)
+    try {
+      await this.runPipeline(flags)
+    } catch (err) {
+      await this.handleError('failed to fetch the egress IP list', err)
+    }
+  }
+
+  async runPipeline (flags) {
+    if (flags.region && !VALID_REGIONS.includes(flags.region)) {
+      this.error(`invalid region "${flags.region}". Expected one of: ${VALID_REGIONS.join(', ')}`)
+    }
+    if (flags['accept-terms'] && !flags['contact-email']) {
+      this.error('--accept-terms requires --contact-email')
+    }
+
+    const host = resolveHost(flags)
+    const orgId = getImsOrgIdOrError()
+    const token = await getAccessToken()
+
+    // First attempt. Most repeat callers already have terms accepted
+    // for their (org, user, surface) tuple and get 200 on the first try.
+    let res = await getIpList({ host, token, orgId, region: flags.region })
+
+    if (res.status === 403 && res.body && res.body.error === 'TERMS_REQUIRED') {
+      await this.handleTermsRequired({ flags, res, host, token, orgId })
+      // Retry once after acceptance.
+      res = await getIpList({ host, token, orgId, region: flags.region })
+      if (res.status === 403 && res.body && res.body.error === 'TERMS_REQUIRED') {
+        this.error('terms were not accepted; try again with --accept-terms --contact-email you@example.com')
+      }
+    }
+
+    if (res.status !== 200) {
+      const detail = (res.body && (res.body.error || res.body.message)) || res.rawBody || `http ${res.status}`
+      this.error(`ip-list service returned ${res.status}: ${detail}`)
+    }
+
+    if (flags.json) {
+      this.logJSON('', res.body)
+    } else {
+      this.log(formatHumanOutput(res.body))
+    }
+  }
+
+  async handleTermsRequired ({ flags, res, host, token, orgId }) {
+    const { termsText, termsUrl, termsVersion } = res.body
+
+    this.log('')
+    this.log(chalk.yellow.bold('This service requires terms acceptance before first use.'))
+    if (termsUrl) this.log(chalk.dim(`Full terms: ${termsUrl}`))
+    this.log('')
+    if (termsText) {
+      this.log(termsText)
+      this.log('')
+    }
+
+    let contactEmail = flags['contact-email']
+    let accepted = flags['accept-terms']
+
+    if (!accepted) {
+      /*
+       * istanbul ignore next -- interactive branch; exercised in manual
+       * demo runs. Unit tests route through --accept-terms to keep the
+       * test path deterministic, matching the way aio-cli-plugin-runtime
+       * tests its other inquirer-backed flows.
+       */
+      const answers = await inquirer.prompt([
+        { name: 'accept', type: 'confirm', message: `Accept terms v${termsVersion}?`, default: false },
+        {
+          name: 'contactEmail',
+          type: 'input',
+          message: 'Contact email (for IP-change notifications):',
+          when: (a) => a.accept && !contactEmail,
+          validate: (v) => /.+@.+\..+/.test(v) || 'enter a valid email address'
+        }
+      ])
+      accepted = answers.accept
+      contactEmail = contactEmail || answers.contactEmail
+    }
+
+    if (!accepted) {
+      this.error('terms were not accepted; cannot fetch the IP list')
+    }
+    if (!contactEmail) {
+      this.error('a contact email is required to accept terms')
+    }
+
+    const acceptRes = await postAcceptTerms({
+      host, token, orgId, contactEmail, termsVersion
+    })
+    if (acceptRes.status !== 200 && acceptRes.status !== 201) {
+      const detail = (acceptRes.body && (acceptRes.body.error || acceptRes.body.message)) ||
+        acceptRes.rawBody || `http ${acceptRes.status}`
+      this.error(`failed to record terms acceptance (${acceptRes.status}): ${detail}`)
+    }
+    this.log(chalk.green(`Terms v${termsVersion} accepted. Fetching the IP list...`))
+  }
+}
+
+IpListGet.flags = {
+  ...RuntimeBaseCommand.flags,
+  region: Flags.string({
+    description: `restrict output to one region (${VALID_REGIONS.join(', ')})`
+  }),
+  'accept-terms': Flags.boolean({
+    description: 'accept the terms non-interactively; requires --contact-email'
+  }),
+  'contact-email': Flags.string({
+    description: 'contact email used when accepting terms and subscribing to change notifications'
+  }),
+  'service-host': Flags.string({
+    description: 'override the ip-list service host (also: AIO_IP_LIST_HOST env var)'
+  }),
+  json: Flags.boolean({
+    description: 'output raw JSON instead of a formatted table'
+  })
+}
+
+IpListGet.description = 'Fetch the current Adobe I/O Runtime egress IP allowlist (IMS-authenticated).\n' +
+  'On first use the service returns the terms of service and the command prompts for acceptance; ' +
+  'pass --accept-terms --contact-email to do that non-interactively.'
+
+IpListGet.aliases = [
+  'rt:ip-list:get'
+]
+
+IpListGet.examples = [
+  '$ aio runtime ip-list get',
+  '$ aio runtime ip-list get --region amer',
+  '$ aio runtime ip-list get --json',
+  '$ aio runtime ip-list get --accept-terms --contact-email platform-ops@example.com'
+]
+
+/* exported for unit tests */
+module.exports = IpListGet
+module.exports.getIpList = getIpList
+module.exports.postAcceptTerms = postAcceptTerms
+module.exports.callService = callService
+module.exports.resolveHost = resolveHost
+module.exports.formatHumanOutput = formatHumanOutput
+module.exports.VALID_REGIONS = VALID_REGIONS
+module.exports.DEFAULT_SERVICE_HOST = DEFAULT_SERVICE_HOST
+module.exports.SERVICE_PATH = SERVICE_PATH

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -13,7 +13,16 @@ governing permissions and limitations under the License.
 const { Flags } = require('@oclif/core')
 const config = require('@adobe/aio-lib-core-config')
 const chalk = require('chalk')
-const inquirer = require('inquirer')
+/*
+ * inquirer v9+ is ESM-first and, when `require`d from a CommonJS caller,
+ * surfaces its public API under a `.default` namespace instead of the
+ * bare module.exports it used to in v8. We use `.default ?? module`
+ * so this command keeps working against either shape — the fallback
+ * matters for tests that mock `inquirer` with a plain `{ prompt: fn }`
+ * object.
+ */
+const inquirerMod = require('inquirer')
+const inquirer = inquirerMod.default || inquirerMod
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
 const { getToken, context } = require('@adobe/aio-lib-ims')
 const { CLI } = require('@adobe/aio-lib-ims/src/context')

--- a/src/commands/runtime/ip-list/get.js
+++ b/src/commands/runtime/ip-list/get.js
@@ -214,7 +214,15 @@ function formatHumanOutput (data) {
   }
   const longest = regionKeys.reduce((m, r) => Math.max(m, r.length), 0)
   for (const region of regionKeys) {
-    const cidrs = [...(regions[region].cidrs || [])].sort()
+    /*
+     * The service returns regions as { [region]: string[] }, a flat
+     * array of CIDR strings. We also tolerate a legacy { cidrs: [] }
+     * shape in case the payload ever gets re-enveloped — no other
+     * client has to care about the difference.
+     */
+    const raw = regions[region]
+    const cidrList = Array.isArray(raw) ? raw : (raw && raw.cidrs) || []
+    const cidrs = [...cidrList].sort()
     lines.push(chalk.bold(region.toUpperCase().padEnd(longest + 2)) + `(${cidrs.length} CIDR${cidrs.length === 1 ? '' : 's'})`)
     for (const cidr of cidrs) {
       lines.push(`  ${cidr}`)

--- a/src/commands/runtime/ip-list/index.js
+++ b/src/commands/runtime/ip-list/index.js
@@ -26,4 +26,9 @@ IndexCommand.aliases = [
   'rt:ip-list'
 ]
 
+IndexCommand.examples = [
+  '$ aio runtime ip-list get',
+  '$ aio runtime ip-list --help'
+]
+
 module.exports = IndexCommand

--- a/src/commands/runtime/ip-list/index.js
+++ b/src/commands/runtime/ip-list/index.js
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Help } = require('@oclif/core')
+const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
+
+class IndexCommand extends RuntimeBaseCommand {
+  async run () {
+    const help = new Help(this.config)
+    await help.showHelp(['runtime:ip-list', '--help'])
+  }
+}
+
+IndexCommand.description = 'Fetch the Adobe I/O Runtime egress IP allowlist'
+
+IndexCommand.aliases = [
+  'rt:ip-list'
+]
+
+module.exports = IndexCommand

--- a/src/commands/runtime/ip-list/index.js
+++ b/src/commands/runtime/ip-list/index.js
@@ -22,6 +22,11 @@ class IndexCommand extends RuntimeBaseCommand {
 
 IndexCommand.description = 'Fetch the Adobe I/O Runtime egress IP allowlist'
 
+// Topic command — delegates to Help and accepts no input, so the
+// OpenWhisk-targeted flags inherited from RuntimeBaseCommand are
+// excluded from --help.
+IndexCommand.flags = {}
+
 IndexCommand.aliases = [
   'rt:ip-list'
 ]

--- a/test/__fixtures__/deploy/export_yaml.yaml
+++ b/test/__fixtures__/deploy/export_yaml.yaml
@@ -23,7 +23,7 @@ project:
             logSize: 10
       triggers:
         meetPerson:
-          namespace: '53444_51981'
+          namespace: 53444_51981
           inputs:
             name: Sam
             place: ''

--- a/test/__fixtures__/deploy/export_yaml_Sequence.yaml
+++ b/test/__fixtures__/deploy/export_yaml_Sequence.yaml
@@ -8,7 +8,7 @@ project:
       actions: {}
       triggers:
         meetPerson:
-          namespace: '53444_51981'
+          namespace: 53444_51981
           inputs:
             name: Sam
             place: ''

--- a/test/__fixtures__/deploy/export_yaml_feed.yaml
+++ b/test/__fixtures__/deploy/export_yaml_feed.yaml
@@ -23,7 +23,7 @@ project:
             logSize: 10
       triggers:
         meetPerson:
-          namespace: '53444_51981'
+          namespace: 53444_51981
           inputs:
             name: Sam
             place: ''

--- a/test/commands/runtime/ip-list/get.test.js
+++ b/test/commands/runtime/ip-list/get.test.js
@@ -374,6 +374,7 @@ describe('run() — terms acceptance flow', () => {
       contactEmail: 'ops@example.com',
       termsVersion: 1,
       surface: 'cli',
+      acceptanceMode: 'programmatic',
       token: 'fake-token',
       imsOrgId: 'BA3E111222@AdobeOrg'
     })
@@ -401,6 +402,10 @@ describe('run() — terms acceptance flow', () => {
     expect(inquirer.prompt).toHaveBeenCalledTimes(1)
     const acceptBody = JSON.parse(global.fetch.mock.calls[1][1].body)
     expect(acceptBody.contactEmail).toBe('ops@example.com')
+    // A prompt-driven acceptance must be tagged "interactive" so the
+    // admin dashboard can distinguish it from flag-driven runs.
+    expect(acceptBody.acceptanceMode).toBe('interactive')
+    expect(acceptBody.surface).toBe('cli')
   })
 
   test('bails out if the user declines at the interactive prompt', async () => {

--- a/test/commands/runtime/ip-list/get.test.js
+++ b/test/commands/runtime/ip-list/get.test.js
@@ -158,10 +158,9 @@ describe('resolveHost', () => {
 })
 
 describe('callService', () => {
-  test('adds Authorization / x-gw-ims-org-id headers and posts JSON', async () => {
+  test('POSTs JSON with token + imsOrgId merged into the body', async () => {
     const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(200, { ok: true }))
     const result = await TheCommand.callService({
-      method: 'POST',
       host: 'host.adobeioruntime.net',
       path: '/api/v1/web/ip-list/accept-terms',
       token: 'abc',
@@ -175,24 +174,45 @@ describe('callService', () => {
       'https://host.adobeioruntime.net/api/v1/web/ip-list/accept-terms',
       expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ contactEmail: 'a@b.com' }),
         headers: expect.objectContaining({
-          Authorization: 'Bearer abc',
-          'x-gw-ims-org-id': 'BA3E@AdobeOrg',
           'Content-Type': 'application/json'
         })
       })
     )
+    const sent = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(sent).toEqual({
+      contactEmail: 'a@b.com',
+      token: 'abc',
+      imsOrgId: 'BA3E@AdobeOrg'
+    })
+  })
+
+  test('does NOT send Authorization / x-gw-ims-org-id headers', async () => {
+    // The cross-org refactor moved the token + org id into the body so the
+    // service can be called by any authenticated Adobe user, independent
+    // of the require-adobe-auth gateway. Guardrail against regressions.
+    const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(200, { ok: true }))
+    await TheCommand.callService({
+      host: 'h.adobeioruntime.net',
+      path: '/p',
+      token: 't',
+      orgId: 'o',
+      body: {},
+      fetchImpl
+    })
+    const sentHeaders = fetchImpl.mock.calls[0][1].headers
+    expect(sentHeaders.Authorization).toBeUndefined()
+    expect(sentHeaders['x-gw-ims-org-id']).toBeUndefined()
   })
 
   test('strips protocol / trailing slashes from host', async () => {
     const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(200, {}))
     await TheCommand.callService({
-      method: 'GET',
       host: 'https://host.adobeioruntime.net///',
       path: '/api/v1/web/ip-list/get-ip-list',
       token: 't',
       orgId: 'o',
+      body: { surface: 'cli' },
       fetchImpl
     })
     expect(fetchImpl.mock.calls[0][0]).toBe('https://host.adobeioruntime.net/api/v1/web/ip-list/get-ip-list')
@@ -201,7 +221,7 @@ describe('callService', () => {
   test('tolerates non-JSON bodies by returning the raw text', async () => {
     const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(503, '<html>503</html>'))
     const result = await TheCommand.callService({
-      method: 'GET', host: 'h', path: '/p', token: 't', orgId: 'o', fetchImpl
+      host: 'h', path: '/p', token: 't', orgId: 'o', body: {}, fetchImpl
     })
     expect(result.status).toBe(503)
     expect(result.body).toBeNull()
@@ -248,9 +268,16 @@ describe('run() — happy path', () => {
     expect(stdout.output).toContain('44.207.149.158/32')
     // no accept-terms call
     expect(global.fetch).toHaveBeenCalledTimes(1)
-    const calledUrl = global.fetch.mock.calls[0][0]
-    expect(calledUrl).toMatch(/\/get-ip-list\?/)
-    expect(calledUrl).toMatch(/surface=cli/)
+    const call = global.fetch.mock.calls[0]
+    expect(call[0]).toMatch(/\/get-ip-list$/)
+    expect(call[1].method).toBe('POST')
+    const body = JSON.parse(call[1].body)
+    expect(body).toMatchObject({
+      surface: 'cli',
+      token: 'fake-token',
+      imsOrgId: 'BA3E111222@AdobeOrg'
+    })
+    expect(body.region).toBeUndefined()
   })
 
   test('--json emits a parseable JSON document', async () => {
@@ -265,8 +292,9 @@ describe('run() — happy path', () => {
     global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
     const cmd = makeCommand(['--region', 'amer'])
     await cmd.run()
-    const url = global.fetch.mock.calls[0][0]
-    expect(url).toMatch(/region=amer/)
+    const body = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(body.region).toBe('amer')
+    expect(body.surface).toBe('cli')
   })
 
   test('--service-host overrides the default', async () => {
@@ -274,6 +302,23 @@ describe('run() — happy path', () => {
     const cmd = makeCommand(['--service-host', 'custom.adobeioruntime.net'])
     await cmd.run()
     expect(global.fetch.mock.calls[0][0]).toMatch(/^https:\/\/custom\.adobeioruntime\.net\//)
+  })
+
+  test('sends token + imsOrgId in every request body', async () => {
+    // Belt-and-braces cross-org-refactor guard: the IMS token must travel
+    // in the POST body so the in-action auth helper can validate it
+    // regardless of which org the caller belongs to.
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
+      .mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await cmd.run()
+    for (const call of global.fetch.mock.calls) {
+      const body = JSON.parse(call[1].body)
+      expect(body.token).toBe('fake-token')
+      expect(body.imsOrgId).toBe('BA3E111222@AdobeOrg')
+    }
   })
 })
 
@@ -310,14 +355,17 @@ describe('run() — terms acceptance flow', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(3)
 
-    // Second call is the POST to accept-terms with the right body + surface=cli.
+    // Second call is the POST to accept-terms with the right body + surface=cli
+    // plus the token/imsOrgId the service needs to validate the caller.
     const acceptCall = global.fetch.mock.calls[1]
     expect(acceptCall[0]).toMatch(/\/accept-terms$/)
     expect(acceptCall[1].method).toBe('POST')
     expect(JSON.parse(acceptCall[1].body)).toEqual({
       contactEmail: 'ops@example.com',
       termsVersion: 1,
-      surface: 'cli'
+      surface: 'cli',
+      token: 'fake-token',
+      imsOrgId: 'BA3E111222@AdobeOrg'
     })
 
     // The human-readable IP list is printed after acceptance.

--- a/test/commands/runtime/ip-list/get.test.js
+++ b/test/commands/runtime/ip-list/get.test.js
@@ -1,0 +1,378 @@
+/*
+Copyright 2026 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+jest.mock('@adobe/aio-lib-core-config')
+jest.mock('@adobe/aio-lib-ims', () => ({
+  getToken: jest.fn(),
+  context: {
+    getCurrent: jest.fn(),
+    setCli: jest.fn()
+  }
+}))
+jest.mock('@adobe/aio-lib-ims/src/context', () => ({ CLI: 'cli' }))
+jest.mock('inquirer')
+
+const { stdout, stderr } = require('stdout-stderr')
+const config = require('@adobe/aio-lib-core-config')
+const { getToken, context } = require('@adobe/aio-lib-ims')
+const inquirer = require('inquirer')
+
+const TheCommand = require('../../../../src/commands/runtime/ip-list/get')
+const IndexCommand = require('../../../../src/commands/runtime/ip-list/index')
+const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand')
+
+/**
+ * Builds a mock fetch-like response. The command reads both res.status and
+ * res.text() — it never re-parses as JSON itself — so we need a minimal
+ * Response shape that satisfies both.
+ *
+ * @param {number} status - HTTP status to simulate.
+ * @param {any} body - Object serialized as the JSON response body, or string
+ *   to send raw. Pass undefined to simulate an empty body.
+ * @returns {{status: number, text: () => Promise<string>}} fetch-like stub.
+ */
+function fetchResponse (status, body) {
+  const text = body === undefined ? '' : (typeof body === 'string' ? body : JSON.stringify(body))
+  return { status, text: async () => text }
+}
+
+/**
+ * Instantiate the command with parsed argv and injected globals.
+ * Mirrors the approach other runtime plugin tests take.
+ *
+ * @param {string[]} argv - CLI args to pass to the command.
+ * @returns {TheCommand} ready-to-run command instance.
+ */
+function makeCommand (argv = []) {
+  return new TheCommand(argv, {
+    runHook: async () => ({ successes: [], failures: [] }),
+    bin: 'aio',
+    userAgent: 'test/0.0.0',
+    findCommand: () => null,
+    pjson: { oclif: {} }
+  })
+}
+
+const IP_LIST_OK = {
+  regions: {
+    amer: { cidrs: ['44.207.149.158/32', '44.208.197.195/32'], version: 3, updatedAt: '2026-04-19T08:00:00Z' },
+    emea: { cidrs: ['52.18.22.1/32'], version: 2, updatedAt: '2026-04-19T08:00:00Z' }
+  },
+  version: 3,
+  lastUpdated: '2026-04-19T08:00:00Z',
+  terms: { version: 1, acceptedAt: '2026-04-18T10:00:00Z' }
+}
+
+const TERMS_REQUIRED_BODY = {
+  error: 'TERMS_REQUIRED',
+  termsUrl: 'https://example.com/terms',
+  termsText: 'By using this service you agree to the terms of service.',
+  termsVersion: 1
+}
+
+let origFetch
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  stdout.start()
+  stderr.start()
+
+  config.get.mockImplementation((key) => {
+    if (key === 'project.org.ims_org_id') return 'BA3E111222@AdobeOrg'
+    return undefined
+  })
+  context.getCurrent.mockResolvedValue(null)
+  context.setCli.mockResolvedValue()
+  getToken.mockResolvedValue('fake-token')
+
+  // jest.mock('inquirer') replaces the module with an auto-mock whose exports
+  // are undefined. Install a jest.fn() here so tests can assert call counts
+  // even when they never route through the interactive branch.
+  inquirer.prompt = jest.fn()
+
+  origFetch = global.fetch
+  global.fetch = jest.fn()
+})
+
+afterEach(() => {
+  stdout.stop()
+  stderr.stop()
+  global.fetch = origFetch
+  delete process.env.AIO_IP_LIST_HOST
+})
+
+test('exports', async () => {
+  expect(typeof TheCommand).toEqual('function')
+  expect(TheCommand.prototype instanceof RuntimeBaseCommand).toBeTruthy()
+})
+
+test('description is set', () => {
+  expect(TheCommand.description).toBeDefined()
+  expect(TheCommand.description.length).toBeGreaterThan(0)
+})
+
+test('aliases include rt:ip-list:get', () => {
+  expect(TheCommand.aliases).toEqual(expect.arrayContaining(['rt:ip-list:get']))
+})
+
+test('examples are non-empty', () => {
+  expect(TheCommand.examples).toBeDefined()
+  expect(TheCommand.examples.length).toBeGreaterThan(0)
+})
+
+// eslint-disable-next-line jest/expect-expect
+test('base flags included in command flags',
+  createTestBaseFlagsFunction(TheCommand, RuntimeBaseCommand)
+)
+
+test('index command is an oclif help wrapper that extends RuntimeBaseCommand', () => {
+  expect(typeof IndexCommand).toEqual('function')
+  expect(IndexCommand.prototype instanceof RuntimeBaseCommand).toBeTruthy()
+  expect(IndexCommand.description).toBeDefined()
+})
+
+describe('resolveHost', () => {
+  test('defaults to the hard-coded service host', () => {
+    expect(TheCommand.resolveHost({})).toBe(TheCommand.DEFAULT_SERVICE_HOST)
+  })
+  test('respects AIO_IP_LIST_HOST', () => {
+    process.env.AIO_IP_LIST_HOST = 'example.adobeioruntime.net'
+    expect(TheCommand.resolveHost({})).toBe('example.adobeioruntime.net')
+  })
+  test('--service-host wins over AIO_IP_LIST_HOST and the default', () => {
+    process.env.AIO_IP_LIST_HOST = 'env-host.adobeioruntime.net'
+    expect(TheCommand.resolveHost({ 'service-host': 'flag-host.adobeioruntime.net' })).toBe('flag-host.adobeioruntime.net')
+  })
+})
+
+describe('callService', () => {
+  test('adds Authorization / x-gw-ims-org-id headers and posts JSON', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(200, { ok: true }))
+    const result = await TheCommand.callService({
+      method: 'POST',
+      host: 'host.adobeioruntime.net',
+      path: '/api/v1/web/ip-list/accept-terms',
+      token: 'abc',
+      orgId: 'BA3E@AdobeOrg',
+      body: { contactEmail: 'a@b.com' },
+      fetchImpl
+    })
+    expect(result.status).toBe(200)
+    expect(result.body).toEqual({ ok: true })
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://host.adobeioruntime.net/api/v1/web/ip-list/accept-terms',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ contactEmail: 'a@b.com' }),
+        headers: expect.objectContaining({
+          Authorization: 'Bearer abc',
+          'x-gw-ims-org-id': 'BA3E@AdobeOrg',
+          'Content-Type': 'application/json'
+        })
+      })
+    )
+  })
+
+  test('strips protocol / trailing slashes from host', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(200, {}))
+    await TheCommand.callService({
+      method: 'GET',
+      host: 'https://host.adobeioruntime.net///',
+      path: '/api/v1/web/ip-list/get-ip-list',
+      token: 't',
+      orgId: 'o',
+      fetchImpl
+    })
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://host.adobeioruntime.net/api/v1/web/ip-list/get-ip-list')
+  })
+
+  test('tolerates non-JSON bodies by returning the raw text', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(503, '<html>503</html>'))
+    const result = await TheCommand.callService({
+      method: 'GET', host: 'h', path: '/p', token: 't', orgId: 'o', fetchImpl
+    })
+    expect(result.status).toBe(503)
+    expect(result.body).toBeNull()
+    expect(result.rawBody).toBe('<html>503</html>')
+  })
+})
+
+describe('formatHumanOutput', () => {
+  test('groups CIDRs by region sorted alphabetically', () => {
+    const out = TheCommand.formatHumanOutput(IP_LIST_OK)
+    expect(out).toMatch(/version:\s+3/)
+    expect(out).toMatch(/lastUpdated:\s+2026-04-19/)
+    expect(out).toMatch(/AMER/)
+    expect(out).toMatch(/EMEA/)
+    // amer appears before emea alphabetically
+    expect(out.indexOf('AMER')).toBeLessThan(out.indexOf('EMEA'))
+    expect(out).toContain('44.207.149.158/32')
+    expect(out).toContain('44.208.197.195/32')
+    expect(out).toContain('52.18.22.1/32')
+  })
+
+  test('handles a freshly-deployed (empty) service gracefully', () => {
+    const out = TheCommand.formatHumanOutput({ regions: {}, version: 0, lastUpdated: null })
+    expect(out).toMatch(/no regions populated/)
+  })
+})
+
+describe('run() — happy path', () => {
+  test('returns IPs without needing terms acceptance', async () => {
+    global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand([])
+    await cmd.run()
+    expect(stdout.output).toContain('AMER')
+    expect(stdout.output).toContain('44.207.149.158/32')
+    // no accept-terms call
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const calledUrl = global.fetch.mock.calls[0][0]
+    expect(calledUrl).toMatch(/\/get-ip-list\?/)
+    expect(calledUrl).toMatch(/surface=cli/)
+  })
+
+  test('--json emits a parseable JSON document', async () => {
+    global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand(['--json'])
+    await cmd.run()
+    const parsed = JSON.parse(stdout.output)
+    expect(parsed).toEqual(IP_LIST_OK)
+  })
+
+  test('--region is forwarded to the service', async () => {
+    global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand(['--region', 'amer'])
+    await cmd.run()
+    const url = global.fetch.mock.calls[0][0]
+    expect(url).toMatch(/region=amer/)
+  })
+
+  test('--service-host overrides the default', async () => {
+    global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand(['--service-host', 'custom.adobeioruntime.net'])
+    await cmd.run()
+    expect(global.fetch.mock.calls[0][0]).toMatch(/^https:\/\/custom\.adobeioruntime\.net\//)
+  })
+})
+
+describe('run() — input validation', () => {
+  test('rejects an unknown region before making any HTTP call', async () => {
+    const cmd = makeCommand(['--region', 'mars'])
+    await expect(cmd.run()).rejects.toThrow()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  test('rejects --accept-terms without --contact-email', async () => {
+    const cmd = makeCommand(['--accept-terms'])
+    await expect(cmd.run()).rejects.toThrow()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  test('errors out if no IMS org id is configured', async () => {
+    config.get.mockReturnValue(undefined)
+    const cmd = makeCommand([])
+    await expect(cmd.run()).rejects.toThrow()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('run() — terms acceptance flow', () => {
+  test('accepts terms non-interactively with --accept-terms + --contact-email, then retries the GET', async () => {
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY)) // initial GET
+      .mockResolvedValueOnce(fetchResponse(200, { ok: true })) // POST accept-terms
+      .mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK)) // retry GET
+
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await cmd.run()
+
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+
+    // Second call is the POST to accept-terms with the right body + surface=cli.
+    const acceptCall = global.fetch.mock.calls[1]
+    expect(acceptCall[0]).toMatch(/\/accept-terms$/)
+    expect(acceptCall[1].method).toBe('POST')
+    expect(JSON.parse(acceptCall[1].body)).toEqual({
+      contactEmail: 'ops@example.com',
+      termsVersion: 1,
+      surface: 'cli'
+    })
+
+    // The human-readable IP list is printed after acceptance.
+    expect(stdout.output).toContain('AMER')
+    expect(stdout.output).toMatch(/Terms v1 accepted/)
+    // Terms text from the server is echoed to the user.
+    expect(stdout.output).toMatch(/agree to the terms/)
+
+    // inquirer was NOT prompted because we supplied non-interactive flags.
+    expect(inquirer.prompt).not.toHaveBeenCalled()
+  })
+
+  test('prompts interactively when --accept-terms is not passed', async () => {
+    inquirer.prompt = jest.fn().mockResolvedValue({ accept: true, contactEmail: 'ops@example.com' })
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
+      .mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+
+    const cmd = makeCommand([])
+    await cmd.run()
+
+    expect(inquirer.prompt).toHaveBeenCalledTimes(1)
+    const acceptBody = JSON.parse(global.fetch.mock.calls[1][1].body)
+    expect(acceptBody.contactEmail).toBe('ops@example.com')
+  })
+
+  test('bails out if the user declines at the interactive prompt', async () => {
+    inquirer.prompt = jest.fn().mockResolvedValue({ accept: false })
+    global.fetch.mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+
+    const cmd = makeCommand([])
+    await expect(cmd.run()).rejects.toThrow()
+    // no accept-terms POST made
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('reports a helpful error when accept-terms POST itself fails', async () => {
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(500, { error: 'database offline' }))
+
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await expect(cmd.run()).rejects.toThrow()
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  test('surfaces a useful error if the service still returns TERMS_REQUIRED after acceptance', async () => {
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await expect(cmd.run()).rejects.toThrow()
+  })
+})
+
+describe('run() — server errors', () => {
+  test('surfaces a 503 raw HTML body (CloudFront-style) with a readable message', async () => {
+    global.fetch.mockResolvedValueOnce(fetchResponse(503, '<html>503 Service Unavailable</html>'))
+    const cmd = makeCommand([])
+    await expect(cmd.run()).rejects.toThrow()
+  })
+
+  test('surfaces a JSON error.message from the server', async () => {
+    global.fetch.mockResolvedValueOnce(fetchResponse(500, { error: 'boom' }))
+    const cmd = makeCommand([])
+    await expect(cmd.run()).rejects.toThrow()
+  })
+})

--- a/test/commands/runtime/ip-list/get.test.js
+++ b/test/commands/runtime/ip-list/get.test.js
@@ -142,10 +142,25 @@ test('examples are non-empty', () => {
   expect(TheCommand.examples.length).toBeGreaterThan(0)
 })
 
-// eslint-disable-next-line jest/expect-expect
-test('base flags included in command flags',
-  createTestBaseFlagsFunction(TheCommand, RuntimeBaseCommand)
-)
+test('exposes only the shared logging flags from RuntimeBaseCommand', () => {
+  // This command does not talk to OpenWhisk, so it deliberately does NOT
+  // spread the full RuntimeBaseCommand.flags set. Inherits only --debug
+  // and --verbose; the OW-specific connection flags (--apihost, --auth,
+  // --cert, --key, --insecure) would be confusing in `--help` because
+  // this command silently ignores them.
+  expect(TheCommand.flags.debug).toBe(RuntimeBaseCommand.flags.debug)
+  expect(TheCommand.flags.verbose).toBe(RuntimeBaseCommand.flags.verbose)
+  expect(TheCommand.flags.apihost).toBeUndefined()
+  expect(TheCommand.flags.auth).toBeUndefined()
+  expect(TheCommand.flags.insecure).toBeUndefined()
+})
+
+test('--service-host is hidden from public help', () => {
+  // Useful escape hatch for stage / manual testing; we don't advertise
+  // it in `--help` because that would make it look like a customer-
+  // supported endpoint override.
+  expect(TheCommand.flags['service-host'].hidden).toBe(true)
+})
 
 test('index command is an oclif help wrapper that extends RuntimeBaseCommand', () => {
   expect(typeof IndexCommand).toEqual('function')
@@ -351,6 +366,41 @@ describe('run() — input validation', () => {
     await expect(cmd.run()).rejects.toThrow()
     expect(global.fetch).not.toHaveBeenCalled()
   })
+
+  test('falls back to console.org.code when project.org.ims_org_id is not set', async () => {
+    // Reproduces the post-`aio console org select` state: the user picked
+    // an org + project + workspace via `aio console`, but never ran
+    // `aio app use`. In that state the IMS org id lives at console.org.code
+    // (the `@AdobeOrg` value), not at console.org.ims_org_id or
+    // project.org.ims_org_id. The command must pick it up from there.
+    config.get.mockImplementation((key) => {
+      if (key === 'project.org.ims_org_id') return undefined
+      if (key === 'console.org.code') return 'C74F69D7594880280A495D09@AdobeOrg'
+      return undefined
+    })
+    global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand([])
+    await cmd.run()
+    const sentBody = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(sentBody.imsOrgId).toBe('C74F69D7594880280A495D09@AdobeOrg')
+  })
+
+  test('prefers project.org.ims_org_id over console.org.code when both are set', async () => {
+    // Precedence: an explicit `aio app use` binding (local project) wins
+    // over a global `aio console org select` binding. Keeps the local
+    // workspace acceptance trail consistent for users who switch between
+    // multiple projects in the same shell.
+    config.get.mockImplementation((key) => {
+      if (key === 'project.org.ims_org_id') return 'PROJECT111@AdobeOrg'
+      if (key === 'console.org.code') return 'CONSOLE222@AdobeOrg'
+      return undefined
+    })
+    global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand([])
+    await cmd.run()
+    const sentBody = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(sentBody.imsOrgId).toBe('PROJECT111@AdobeOrg')
+  })
 })
 
 describe('run() — terms acceptance flow', () => {
@@ -381,12 +431,34 @@ describe('run() — terms acceptance flow', () => {
 
     // The human-readable IP list is printed after acceptance.
     expect(stdout.output).toContain('AMER')
-    expect(stdout.output).toMatch(/Terms v1 accepted/)
-    // Terms text from the server is echoed to the user.
-    expect(stdout.output).toMatch(/agree to the terms/)
+    // Informational messages (terms text + acceptance notice) go to
+    // stderr so that `--json` consumers get clean, parseable stdout.
+    expect(stderr.output).toMatch(/Terms v1 accepted/)
+    expect(stderr.output).toMatch(/agree to the terms/)
 
     // inquirer was NOT prompted because we supplied non-interactive flags.
     expect(inquirer.prompt).not.toHaveBeenCalled()
+  })
+
+  test('`--json` first-use produces parseable JSON (terms text on stderr only)', async () => {
+    // Regression guard for: on first use with --json + --accept-terms,
+    // info messages like the terms text and "accepted" notice must not
+    // leak onto stdout, or `aio runtime ip-list get --json | jq ...`
+    // breaks for scripted consumers.
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
+      .mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+
+    const cmd = makeCommand(['--json', '--accept-terms', '--contact-email', 'ops@example.com'])
+    await cmd.run()
+
+    // stdout must be valid JSON, nothing else.
+    const parsed = JSON.parse(stdout.output)
+    expect(parsed).toEqual(IP_LIST_OK)
+    // terms text + acceptance line landed on stderr, not stdout.
+    expect(stderr.output).toMatch(/agree to the terms/)
+    expect(stderr.output).toMatch(/Terms v1 accepted/)
   })
 
   test('prompts interactively when --accept-terms is not passed', async () => {
@@ -436,6 +508,242 @@ describe('run() — terms acceptance flow', () => {
 
     const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
     await expect(cmd.run()).rejects.toThrow()
+  })
+})
+
+describe('IMS context selection', () => {
+  test('uses the active IMS context name when one is set (non-CLI)', async () => {
+    // When the user has already selected an IMS context (e.g. via
+    // `aio auth login`), the command must use *that* token rather than
+    // forcing the bare CLI context. Guards against accidentally signing
+    // requests as the wrong identity.
+    context.getCurrent.mockResolvedValue('user-context')
+    global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+
+    const cmd = makeCommand([])
+    await cmd.run()
+
+    expect(getToken).toHaveBeenCalledWith('user-context')
+    // setCli is only invoked when we fall back to the CLI default.
+    expect(context.setCli).not.toHaveBeenCalled()
+  })
+
+  test('falls back to setCli when no current context exists', async () => {
+    // beforeEach sets getCurrent -> null; this test pins that behaviour
+    // and asserts the fallback wires the bare CLI output flag.
+    context.getCurrent.mockResolvedValue(null)
+    global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+
+    const cmd = makeCommand([])
+    await cmd.run()
+
+    expect(context.setCli).toHaveBeenCalledWith({ 'cli.bare-output': true }, false)
+    expect(getToken).toHaveBeenCalledWith('cli')
+  })
+})
+
+describe('interactive terms prompt config', () => {
+  test('email prompt validate + when callbacks exercise the regex and gating', async () => {
+    // The prompt config builds two callbacks inquirer invokes against
+    // user input. Mocked inquirer.prompt skips them by default, so we
+    // assert from inside the mock implementation (where the closure
+    // variables match what the real prompt would see).
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
+      .mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+
+    inquirer.prompt = jest.fn().mockImplementation(async (questions) => {
+      const emailQ = questions.find((q) => q.name === 'contactEmail')
+      // validate(): rejects malformed, accepts well-formed.
+      expect(emailQ.validate('not-an-email')).toBe('enter a valid email address')
+      expect(emailQ.validate('user@example.com')).toBe(true)
+      // when(): asks iff accepted AND no contact email already supplied.
+      // Closure variable contactEmail is currently undefined (no flag passed).
+      expect(emailQ.when({ accept: true })).toBe(true)
+      expect(emailQ.when({ accept: false })).toBe(false)
+      return { accept: true, contactEmail: 'ops@example.com' }
+    })
+
+    const cmd = makeCommand([])
+    await cmd.run()
+  })
+
+  test('email prompt is skipped when --contact-email is already supplied', async () => {
+    // when() must be false in this case so inquirer never asks for the
+    // email a second time.
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
+      .mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+
+    inquirer.prompt = jest.fn().mockImplementation(async (questions) => {
+      const emailQ = questions.find((q) => q.name === 'contactEmail')
+      expect(emailQ.when({ accept: true })).toBe(false)
+      return { accept: true }
+    })
+
+    const cmd = makeCommand(['--contact-email', 'preset@example.com'])
+    await cmd.run()
+  })
+
+  test('errors if the user accepts at the prompt but provides no contact email', async () => {
+    // If the prompt returns accept=true and an empty contactEmail (e.g.
+    // the user dismissed the email input), we fail fast rather than
+    // sending a malformed accept-terms request.
+    inquirer.prompt = jest.fn().mockResolvedValue({ accept: true })
+    global.fetch.mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+
+    const cmd = makeCommand([])
+    await expect(cmd.run()).rejects.toThrow()
+    // accept-terms POST never happened — we bailed out first.
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('IndexCommand', () => {
+  test('run() invokes Help.showHelp for the ip-list command group', async () => {
+    // The parent `aio runtime ip-list` (no subcommand) is just a help
+    // wrapper. Spy on oclif's Help.prototype.showHelp to confirm the
+    // class wires through correctly.
+    const oclif = require('@oclif/core')
+    const showHelpSpy = jest.spyOn(oclif.Help.prototype, 'showHelp').mockResolvedValue()
+
+    const cmd = new IndexCommand([], {
+      runHook: async () => ({ successes: [], failures: [] }),
+      bin: 'aio',
+      userAgent: 'test/0.0.0',
+      findCommand: () => null,
+      pjson: { oclif: {} }
+    })
+    await cmd.run()
+    expect(showHelpSpy).toHaveBeenCalledWith(['runtime:ip-list', '--help'])
+    showHelpSpy.mockRestore()
+  })
+
+  test('exposes non-empty examples', () => {
+    expect(IndexCommand.examples).toBeDefined()
+    expect(IndexCommand.examples.length).toBeGreaterThan(0)
+  })
+})
+
+describe('branch-coverage edge cases', () => {
+  test('callService tolerates an undefined body', async () => {
+    // Guards the `body || {}` short-circuit when callers omit body
+    // entirely (e.g. a future GET-style helper).
+    const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(200, { ok: true }))
+    await TheCommand.callService({
+      host: 'h', path: '/p', token: 't', orgId: 'o', fetchImpl
+    })
+    const sent = JSON.parse(fetchImpl.mock.calls[0][1].body)
+    expect(sent).toEqual({ token: 't', imsOrgId: 'o' })
+  })
+
+  test('callService surfaces an empty response body cleanly', async () => {
+    // `if (text)` short-circuits JSON parse when the server returns no
+    // body at all (e.g. 204 No Content). body must be null, rawBody ''.
+    const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(204, undefined))
+    const r = await TheCommand.callService({
+      host: 'h', path: '/p', token: 't', orgId: 'o', body: {}, fetchImpl
+    })
+    expect(r.status).toBe(204)
+    expect(r.body).toBeNull()
+    expect(r.rawBody).toBe('')
+  })
+
+  test('formatHumanOutput tolerates a response with no `regions` key', () => {
+    // `data.regions || {}` short-circuit when the server omits the key.
+    const out = TheCommand.formatHumanOutput({ version: 0, lastUpdated: null })
+    expect(out).toMatch(/no regions populated/)
+  })
+
+  test('formatHumanOutput tolerates a falsy `raw` value for a region', () => {
+    // Defensive: if the server ever returns `{ regions: { amer: null } }`,
+    // we must not throw. `Array.isArray(raw) ? raw : (raw && raw.cidrs) || []`
+    // — null short-circuits to []; the region just renders as "(0 CIDRs)".
+    const out = TheCommand.formatHumanOutput({
+      regions: { amer: null },
+      version: 1,
+      lastUpdated: '2026-04-21T00:00:00Z'
+    })
+    expect(out).toMatch(/AMER/)
+    expect(out).toMatch(/0 CIDRs/)
+  })
+
+  test('error detail falls back to "http <status>" when the server returns no body', async () => {
+    // Covers `|| `http ${res.status}`` in the get-ip-list error path.
+    global.fetch.mockResolvedValueOnce(fetchResponse(500, undefined))
+    const cmd = makeCommand([])
+    await expect(cmd.run()).rejects.toThrow(/500/)
+  })
+
+  test('accept-terms error detail falls back to rawBody when JSON body is missing', async () => {
+    // Covers the `|| acceptRes.rawBody` fallback when the failure
+    // response from accept-terms isn't JSON-parseable.
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(502, '<html>bad gateway</html>'))
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await expect(cmd.run()).rejects.toThrow()
+  })
+
+  test('accept-terms error detail falls back to "http <status>" with no body or rawBody', async () => {
+    // Covers the final `|| `http ${acceptRes.status}`` branch.
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(500, undefined))
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await expect(cmd.run()).rejects.toThrow()
+  })
+
+  test('get-ip-list error detail uses body.message when no body.error is present', async () => {
+    // Covers the `res.body.message` branch of the detail-resolution chain.
+    global.fetch.mockResolvedValueOnce(fetchResponse(500, { message: 'oops' }))
+    const cmd = makeCommand([])
+    await expect(cmd.run()).rejects.toThrow(/oops/)
+  })
+
+  test('accept-terms error detail uses body.message when no body.error is present', async () => {
+    // Covers the matching `acceptRes.body.message` branch.
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(500, { message: 'db offline' }))
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await expect(cmd.run()).rejects.toThrow(/db offline/)
+  })
+
+  test('accept-terms accepts a 201 Created response as success (not just 200)', async () => {
+    // The status guard `status !== 200 && status !== 201` must treat 201
+    // the same as 200; the second clause is otherwise never exercised.
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
+      .mockResolvedValueOnce(fetchResponse(201, { ok: true }))
+      .mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await cmd.run()
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+  })
+
+  test('terms prompt omits the "Full terms" link when the server returns no termsUrl', async () => {
+    // Covers the `if (termsUrl)` falsy branch in handleTermsRequired.
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, { ...TERMS_REQUIRED_BODY, termsUrl: undefined }))
+      .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
+      .mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await cmd.run()
+    expect(stderr.output).not.toMatch(/Full terms/)
+  })
+
+  test('terms prompt omits the body block when the server returns no termsText', async () => {
+    // Covers the `if (termsText)` falsy branch in handleTermsRequired.
+    global.fetch
+      .mockResolvedValueOnce(fetchResponse(403, { ...TERMS_REQUIRED_BODY, termsText: undefined }))
+      .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
+      .mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
+    const cmd = makeCommand(['--accept-terms', '--contact-email', 'ops@example.com'])
+    await cmd.run()
+    expect(stderr.output).not.toMatch(/agree to the terms/)
   })
 })
 

--- a/test/commands/runtime/ip-list/get.test.js
+++ b/test/commands/runtime/ip-list/get.test.js
@@ -62,10 +62,13 @@ function makeCommand (argv = []) {
   })
 }
 
+// Matches the wire shape returned by `get-ip-list` on Stage — regions map
+// to a flat array of CIDR strings (not a nested { cidrs: [...] } object).
+// Verified against a real Stage response on 2026-04-21.
 const IP_LIST_OK = {
   regions: {
-    amer: { cidrs: ['44.207.149.158/32', '44.208.197.195/32'], version: 3, updatedAt: '2026-04-19T08:00:00Z' },
-    emea: { cidrs: ['52.18.22.1/32'], version: 2, updatedAt: '2026-04-19T08:00:00Z' }
+    amer: ['44.207.149.158/32', '44.208.197.195/32'],
+    emea: ['52.18.22.1/32']
   },
   version: 3,
   lastUpdated: '2026-04-19T08:00:00Z',
@@ -223,6 +226,16 @@ describe('formatHumanOutput', () => {
   test('handles a freshly-deployed (empty) service gracefully', () => {
     const out = TheCommand.formatHumanOutput({ regions: {}, version: 0, lastUpdated: null })
     expect(out).toMatch(/no regions populated/)
+  })
+
+  test('tolerates the legacy { cidrs: [...] } region envelope', () => {
+    // Defense in depth for a re-enveloped future wire shape.
+    const out = TheCommand.formatHumanOutput({
+      regions: { amer: { cidrs: ['10.0.0.1/32'] } },
+      version: 1,
+      lastUpdated: '2026-04-21T00:00:00Z'
+    })
+    expect(out).toContain('10.0.0.1/32')
   })
 })
 

--- a/test/commands/runtime/ip-list/get.test.js
+++ b/test/commands/runtime/ip-list/get.test.js
@@ -19,11 +19,9 @@ jest.mock('@adobe/aio-lib-ims', () => ({
   }
 }))
 jest.mock('@adobe/aio-lib-ims/src/context', () => ({ CLI: 'cli' }))
-// inquirer v9+ exposes `.prompt` under `.default` when required from CJS.
-// Our command normalizes that (`.default || module`). Mock the module in a
-// way that works for both shapes so tests stay agnostic to the inquirer
-// major version: `inquirer.prompt` and `inquirer.default.prompt` are the
-// same jest.fn() instance.
+// inquirer v9+ exposes `.prompt` under `.default` when required from
+// CommonJS. The mock exports the same jest.fn() under both shapes so
+// tests remain agnostic to the inquirer major version.
 jest.mock('inquirer', () => {
   const prompt = jest.fn()
   const mod = { prompt }
@@ -41,13 +39,12 @@ const IndexCommand = require('../../../../src/commands/runtime/ip-list/index')
 const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand')
 
 /**
- * Builds a mock fetch-like response. The command reads both res.status and
- * res.text() — it never re-parses as JSON itself — so we need a minimal
- * Response shape that satisfies both.
+ * Builds a minimal fetch-like Response shape that satisfies the command's
+ * usage of `res.status` and `res.text()`.
  *
  * @param {number} status - HTTP status to simulate.
- * @param {any} body - Object serialized as the JSON response body, or string
- *   to send raw. Pass undefined to simulate an empty body.
+ * @param {any} body - Object serialized as the JSON response body, a
+ *   string to send raw, or undefined for an empty body.
  * @returns {{status: number, text: () => Promise<string>}} fetch-like stub.
  */
 function fetchResponse (status, body) {
@@ -56,11 +53,10 @@ function fetchResponse (status, body) {
 }
 
 /**
- * Instantiate the command with parsed argv and injected globals.
- * Mirrors the approach other runtime plugin tests take.
+ * Instantiate the command with parsed argv and a minimal oclif config.
  *
  * @param {string[]} argv - CLI args to pass to the command.
- * @returns {TheCommand} ready-to-run command instance.
+ * @returns {TheCommand} Ready-to-run command instance.
  */
 function makeCommand (argv = []) {
   return new TheCommand(argv, {
@@ -72,9 +68,8 @@ function makeCommand (argv = []) {
   })
 }
 
-// Matches the wire shape returned by `get-ip-list` on Stage — regions map
-// to a flat array of CIDR strings (not a nested { cidrs: [...] } object).
-// Verified against a real Stage response on 2026-04-21.
+// Mirrors the current wire shape returned by `get-ip-list`: each region
+// maps to a flat array of CIDR strings.
 const IP_LIST_OK = {
   regions: {
     amer: ['44.207.149.158/32', '44.208.197.195/32'],
@@ -107,9 +102,8 @@ beforeEach(() => {
   context.setCli.mockResolvedValue()
   getToken.mockResolvedValue('fake-token')
 
-  // jest.mock('inquirer') replaces the module with an auto-mock whose exports
-  // are undefined. Install a jest.fn() here so tests can assert call counts
-  // even when they never route through the interactive branch.
+  // Re-install a fresh jest.fn() so tests can assert call counts even
+  // when they never enter the interactive branch.
   inquirer.prompt = jest.fn()
 
   origFetch = global.fetch
@@ -143,11 +137,9 @@ test('examples are non-empty', () => {
 })
 
 test('exposes only the shared logging flags from RuntimeBaseCommand', () => {
-  // This command does not talk to OpenWhisk, so it deliberately does NOT
-  // spread the full RuntimeBaseCommand.flags set. Inherits only --debug
-  // and --verbose; the OW-specific connection flags (--apihost, --auth,
-  // --cert, --key, --insecure) would be confusing in `--help` because
-  // this command silently ignores them.
+  // Inherits --debug and --verbose only; OpenWhisk-targeted flags
+  // (--apihost, --auth, --cert, --key, --insecure) are excluded because
+  // this command does not call OpenWhisk.
   expect(TheCommand.flags.debug).toBe(RuntimeBaseCommand.flags.debug)
   expect(TheCommand.flags.verbose).toBe(RuntimeBaseCommand.flags.verbose)
   expect(TheCommand.flags.apihost).toBeUndefined()
@@ -156,9 +148,8 @@ test('exposes only the shared logging flags from RuntimeBaseCommand', () => {
 })
 
 test('--service-host is hidden from public help', () => {
-  // Useful escape hatch for stage / manual testing; we don't advertise
-  // it in `--help` because that would make it look like a customer-
-  // supported endpoint override.
+  // Internal escape hatch for stage testing; not a supported endpoint
+  // override, so it is hidden from --help.
   expect(TheCommand.flags['service-host'].hidden).toBe(true)
 })
 
@@ -213,9 +204,8 @@ describe('callService', () => {
   })
 
   test('does NOT send Authorization / x-gw-ims-org-id headers', async () => {
-    // The cross-org refactor moved the token + org id into the body so the
-    // service can be called by any authenticated Adobe user, independent
-    // of the require-adobe-auth gateway. Guardrail against regressions.
+    // The token and imsOrgId travel in the JSON body so the service
+    // can validate the caller in-action rather than at the gateway.
     const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(200, { ok: true }))
     await TheCommand.callService({
       host: 'h.adobeioruntime.net',
@@ -274,7 +264,7 @@ describe('formatHumanOutput', () => {
   })
 
   test('tolerates the legacy { cidrs: [...] } region envelope', () => {
-    // Defense in depth for a re-enveloped future wire shape.
+    // Forward-compat: a re-enveloped future wire shape must still render.
     const out = TheCommand.formatHumanOutput({
       regions: { amer: { cidrs: ['10.0.0.1/32'] } },
       version: 1,
@@ -291,7 +281,7 @@ describe('run() — happy path', () => {
     await cmd.run()
     expect(stdout.output).toContain('AMER')
     expect(stdout.output).toContain('44.207.149.158/32')
-    // no accept-terms call
+    // No accept-terms call is made when the user already has acceptance on file.
     expect(global.fetch).toHaveBeenCalledTimes(1)
     const call = global.fetch.mock.calls[0]
     expect(call[0]).toMatch(/\/get-ip-list$/)
@@ -330,9 +320,8 @@ describe('run() — happy path', () => {
   })
 
   test('sends token + imsOrgId in every request body', async () => {
-    // Belt-and-braces cross-org-refactor guard: the IMS token must travel
-    // in the POST body so the in-action auth helper can validate it
-    // regardless of which org the caller belongs to.
+    // Every outbound POST must carry the IMS token and org id in the
+    // body so the service can validate the caller in-action.
     global.fetch
       .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
       .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
@@ -350,29 +339,34 @@ describe('run() — happy path', () => {
 describe('run() — input validation', () => {
   test('rejects an unknown region before making any HTTP call', async () => {
     const cmd = makeCommand(['--region', 'mars'])
-    await expect(cmd.run()).rejects.toThrow()
+    await expect(cmd.run()).rejects.toThrow(/invalid region "mars"/)
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
   test('rejects --accept-terms without --contact-email', async () => {
     const cmd = makeCommand(['--accept-terms'])
-    await expect(cmd.run()).rejects.toThrow()
+    await expect(cmd.run()).rejects.toThrow(/--accept-terms requires --contact-email/)
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
   test('errors out if no IMS org id is configured', async () => {
+    // Locks the exact multi-line wording so a future copy edit cannot
+    // silently regress the customer-facing first-use error.
     config.get.mockReturnValue(undefined)
     const cmd = makeCommand([])
-    await expect(cmd.run()).rejects.toThrow()
+    await expect(cmd.run()).rejects.toThrow(
+      'IMS org id not found in aio config.\n\n' +
+      'Run one of the following and try again:\n' +
+      '  aio console org select\n' +
+      '  aio app use'
+    )
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
   test('falls back to console.org.code when project.org.ims_org_id is not set', async () => {
-    // Reproduces the post-`aio console org select` state: the user picked
-    // an org + project + workspace via `aio console`, but never ran
-    // `aio app use`. In that state the IMS org id lives at console.org.code
-    // (the `@AdobeOrg` value), not at console.org.ims_org_id or
-    // project.org.ims_org_id. The command must pick it up from there.
+    // After `aio console org select` without a subsequent `aio app use`,
+    // the IMS org id is stored at console.org.code rather than
+    // project.org.ims_org_id; the command must resolve it from there.
     config.get.mockImplementation((key) => {
       if (key === 'project.org.ims_org_id') return undefined
       if (key === 'console.org.code') return 'C74F69D7594880280A495D09@AdobeOrg'
@@ -386,10 +380,8 @@ describe('run() — input validation', () => {
   })
 
   test('prefers project.org.ims_org_id over console.org.code when both are set', async () => {
-    // Precedence: an explicit `aio app use` binding (local project) wins
-    // over a global `aio console org select` binding. Keeps the local
-    // workspace acceptance trail consistent for users who switch between
-    // multiple projects in the same shell.
+    // An explicit `aio app use` binding (project-local) takes precedence
+    // over the global `aio console org select` binding.
     config.get.mockImplementation((key) => {
       if (key === 'project.org.ims_org_id') return 'PROJECT111@AdobeOrg'
       if (key === 'console.org.code') return 'CONSOLE222@AdobeOrg'
@@ -429,22 +421,21 @@ describe('run() — terms acceptance flow', () => {
       imsOrgId: 'BA3E111222@AdobeOrg'
     })
 
-    // The human-readable IP list is printed after acceptance.
+    // The human-readable IP list is printed on stdout after acceptance.
     expect(stdout.output).toContain('AMER')
-    // Informational messages (terms text + acceptance notice) go to
-    // stderr so that `--json` consumers get clean, parseable stdout.
+    // Informational messages (terms text and acceptance notice) are
+    // written to stderr so --json consumers receive clean stdout.
     expect(stderr.output).toMatch(/Terms v1 accepted/)
     expect(stderr.output).toMatch(/agree to the terms/)
 
-    // inquirer was NOT prompted because we supplied non-interactive flags.
+    // inquirer is not invoked when non-interactive flags are supplied.
     expect(inquirer.prompt).not.toHaveBeenCalled()
   })
 
   test('`--json` first-use produces parseable JSON (terms text on stderr only)', async () => {
-    // Regression guard for: on first use with --json + --accept-terms,
-    // info messages like the terms text and "accepted" notice must not
-    // leak onto stdout, or `aio runtime ip-list get --json | jq ...`
-    // breaks for scripted consumers.
+    // With --json + --accept-terms on first use, informational output
+    // must remain on stderr so stdout stays a valid JSON document for
+    // scripted consumers (e.g. `aio runtime ip-list get --json | jq`).
     global.fetch
       .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
       .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
@@ -474,8 +465,8 @@ describe('run() — terms acceptance flow', () => {
     expect(inquirer.prompt).toHaveBeenCalledTimes(1)
     const acceptBody = JSON.parse(global.fetch.mock.calls[1][1].body)
     expect(acceptBody.contactEmail).toBe('ops@example.com')
-    // A prompt-driven acceptance must be tagged "interactive" so the
-    // admin dashboard can distinguish it from flag-driven runs.
+    // Prompt-driven acceptance is recorded as "interactive" so the
+    // server can distinguish it from flag-driven runs.
     expect(acceptBody.acceptanceMode).toBe('interactive')
     expect(acceptBody.surface).toBe('cli')
   })
@@ -486,7 +477,7 @@ describe('run() — terms acceptance flow', () => {
 
     const cmd = makeCommand([])
     await expect(cmd.run()).rejects.toThrow()
-    // no accept-terms POST made
+    // The accept-terms POST is never sent on a declined prompt.
     expect(global.fetch).toHaveBeenCalledTimes(1)
   })
 
@@ -513,10 +504,9 @@ describe('run() — terms acceptance flow', () => {
 
 describe('IMS context selection', () => {
   test('uses the active IMS context name when one is set (non-CLI)', async () => {
-    // When the user has already selected an IMS context (e.g. via
-    // `aio auth login`), the command must use *that* token rather than
-    // forcing the bare CLI context. Guards against accidentally signing
-    // requests as the wrong identity.
+    // When an IMS context is already active (for example via
+    // `aio auth login`), the command must request a token for that
+    // context rather than forcing the bare CLI context.
     context.getCurrent.mockResolvedValue('user-context')
     global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
 
@@ -524,13 +514,13 @@ describe('IMS context selection', () => {
     await cmd.run()
 
     expect(getToken).toHaveBeenCalledWith('user-context')
-    // setCli is only invoked when we fall back to the CLI default.
+    // setCli runs only on the no-current-context fallback path.
     expect(context.setCli).not.toHaveBeenCalled()
   })
 
   test('falls back to setCli when no current context exists', async () => {
-    // beforeEach sets getCurrent -> null; this test pins that behaviour
-    // and asserts the fallback wires the bare CLI output flag.
+    // When no IMS context is active, the command falls back to the
+    // bare CLI context with `cli.bare-output: true`.
     context.getCurrent.mockResolvedValue(null)
     global.fetch.mockResolvedValueOnce(fetchResponse(200, IP_LIST_OK))
 
@@ -544,10 +534,9 @@ describe('IMS context selection', () => {
 
 describe('interactive terms prompt config', () => {
   test('email prompt validate + when callbacks exercise the regex and gating', async () => {
-    // The prompt config builds two callbacks inquirer invokes against
-    // user input. Mocked inquirer.prompt skips them by default, so we
-    // assert from inside the mock implementation (where the closure
-    // variables match what the real prompt would see).
+    // The prompt config builds `validate` and `when` callbacks that
+    // inquirer invokes against user input. The mock invokes them
+    // directly so the closure variables match what inquirer would see.
     global.fetch
       .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
       .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
@@ -555,11 +544,11 @@ describe('interactive terms prompt config', () => {
 
     inquirer.prompt = jest.fn().mockImplementation(async (questions) => {
       const emailQ = questions.find((q) => q.name === 'contactEmail')
-      // validate(): rejects malformed, accepts well-formed.
+      // validate(): rejects malformed input, accepts well-formed.
       expect(emailQ.validate('not-an-email')).toBe('enter a valid email address')
       expect(emailQ.validate('user@example.com')).toBe(true)
-      // when(): asks iff accepted AND no contact email already supplied.
-      // Closure variable contactEmail is currently undefined (no flag passed).
+      // when(): asks for the email iff `accept` is true and no
+      // --contact-email was supplied on the command line.
       expect(emailQ.when({ accept: true })).toBe(true)
       expect(emailQ.when({ accept: false })).toBe(false)
       return { accept: true, contactEmail: 'ops@example.com' }
@@ -570,8 +559,8 @@ describe('interactive terms prompt config', () => {
   })
 
   test('email prompt is skipped when --contact-email is already supplied', async () => {
-    // when() must be false in this case so inquirer never asks for the
-    // email a second time.
+    // when() must return false so inquirer does not re-prompt for an
+    // email that was already provided on the command line.
     global.fetch
       .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
       .mockResolvedValueOnce(fetchResponse(200, { ok: true }))
@@ -588,24 +577,22 @@ describe('interactive terms prompt config', () => {
   })
 
   test('errors if the user accepts at the prompt but provides no contact email', async () => {
-    // If the prompt returns accept=true and an empty contactEmail (e.g.
-    // the user dismissed the email input), we fail fast rather than
-    // sending a malformed accept-terms request.
+    // If the prompt returns accept=true with an empty contactEmail,
+    // the command exits before sending a malformed accept-terms request.
     inquirer.prompt = jest.fn().mockResolvedValue({ accept: true })
     global.fetch.mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
 
     const cmd = makeCommand([])
     await expect(cmd.run()).rejects.toThrow()
-    // accept-terms POST never happened — we bailed out first.
+    // The accept-terms POST is never sent when the email is missing.
     expect(global.fetch).toHaveBeenCalledTimes(1)
   })
 })
 
 describe('IndexCommand', () => {
   test('run() invokes Help.showHelp for the ip-list command group', async () => {
-    // The parent `aio runtime ip-list` (no subcommand) is just a help
-    // wrapper. Spy on oclif's Help.prototype.showHelp to confirm the
-    // class wires through correctly.
+    // `aio runtime ip-list` with no subcommand delegates to oclif Help;
+    // spy on Help.prototype.showHelp to confirm the wiring.
     const oclif = require('@oclif/core')
     const showHelpSpy = jest.spyOn(oclif.Help.prototype, 'showHelp').mockResolvedValue()
 
@@ -625,12 +612,43 @@ describe('IndexCommand', () => {
     expect(IndexCommand.examples).toBeDefined()
     expect(IndexCommand.examples.length).toBeGreaterThan(0)
   })
+
+  test('overrides flags to {} so the topic --help does not list OpenWhisk flags', () => {
+    // The topic command accepts no input, so OpenWhisk-targeted flags
+    // inherited from RuntimeBaseCommand must not appear in --help.
+    expect(IndexCommand.flags).toEqual({})
+    for (const owFlag of ['apihost', 'auth', 'cert', 'key', 'insecure']) {
+      expect(IndexCommand.flags).not.toHaveProperty(owFlag)
+    }
+  })
+})
+
+describe('customer-visible help text', () => {
+  test('IpListGet description does not reference auth mechanism in --help', () => {
+    // The authentication mechanism is an implementation detail that
+    // does not belong in the customer-facing description.
+    expect(TheCommand.description).toMatch(/Adobe I\/O Runtime egress IP allowlist/)
+    expect(TheCommand.description).not.toMatch(/IMS-authenticated/i)
+    expect(TheCommand.description).not.toMatch(/OAuth/i)
+    expect(TheCommand.description).not.toMatch(/JWT/i)
+  })
+
+  test('IpListGet flags do not expose RuntimeBaseCommand OpenWhisk flags', () => {
+    // --apihost / --auth / --cert / --key / --insecure are silently
+    // ignored by this command and must not appear in --help.
+    for (const owFlag of ['apihost', 'auth', 'cert', 'key', 'insecure']) {
+      expect(TheCommand.flags).not.toHaveProperty(owFlag)
+    }
+    // --service-host is the internal escape hatch: present in flags
+    // but hidden from --help output.
+    expect(TheCommand.flags['service-host']).toBeDefined()
+    expect(TheCommand.flags['service-host'].hidden).toBe(true)
+  })
 })
 
 describe('branch-coverage edge cases', () => {
   test('callService tolerates an undefined body', async () => {
-    // Guards the `body || {}` short-circuit when callers omit body
-    // entirely (e.g. a future GET-style helper).
+    // Exercises the `body || {}` short-circuit when callers omit body.
     const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(200, { ok: true }))
     await TheCommand.callService({
       host: 'h', path: '/p', token: 't', orgId: 'o', fetchImpl
@@ -640,8 +658,8 @@ describe('branch-coverage edge cases', () => {
   })
 
   test('callService surfaces an empty response body cleanly', async () => {
-    // `if (text)` short-circuits JSON parse when the server returns no
-    // body at all (e.g. 204 No Content). body must be null, rawBody ''.
+    // For an empty body (e.g. 204 No Content), `body` must be null and
+    // `rawBody` must be the empty string — never undefined.
     const fetchImpl = jest.fn().mockResolvedValue(fetchResponse(204, undefined))
     const r = await TheCommand.callService({
       host: 'h', path: '/p', token: 't', orgId: 'o', body: {}, fetchImpl
@@ -658,9 +676,8 @@ describe('branch-coverage edge cases', () => {
   })
 
   test('formatHumanOutput tolerates a falsy `raw` value for a region', () => {
-    // Defensive: if the server ever returns `{ regions: { amer: null } }`,
-    // we must not throw. `Array.isArray(raw) ? raw : (raw && raw.cidrs) || []`
-    // — null short-circuits to []; the region just renders as "(0 CIDRs)".
+    // A null region value (e.g. `{ regions: { amer: null } }`) must
+    // not throw; the region renders as "(0 CIDRs)".
     const out = TheCommand.formatHumanOutput({
       regions: { amer: null },
       version: 1,
@@ -713,8 +730,8 @@ describe('branch-coverage edge cases', () => {
   })
 
   test('accept-terms accepts a 201 Created response as success (not just 200)', async () => {
-    // The status guard `status !== 200 && status !== 201` must treat 201
-    // the same as 200; the second clause is otherwise never exercised.
+    // The success guard treats 200 and 201 as equivalent; this
+    // exercises the 201 branch.
     global.fetch
       .mockResolvedValueOnce(fetchResponse(403, TERMS_REQUIRED_BODY))
       .mockResolvedValueOnce(fetchResponse(201, { ok: true }))

--- a/test/commands/runtime/ip-list/get.test.js
+++ b/test/commands/runtime/ip-list/get.test.js
@@ -19,7 +19,17 @@ jest.mock('@adobe/aio-lib-ims', () => ({
   }
 }))
 jest.mock('@adobe/aio-lib-ims/src/context', () => ({ CLI: 'cli' }))
-jest.mock('inquirer')
+// inquirer v9+ exposes `.prompt` under `.default` when required from CJS.
+// Our command normalizes that (`.default || module`). Mock the module in a
+// way that works for both shapes so tests stay agnostic to the inquirer
+// major version: `inquirer.prompt` and `inquirer.default.prompt` are the
+// same jest.fn() instance.
+jest.mock('inquirer', () => {
+  const prompt = jest.fn()
+  const mod = { prompt }
+  mod.default = mod
+  return mod
+})
 
 const { stdout, stderr } = require('stdout-stderr')
 const config = require('@adobe/aio-lib-core-config')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds  a new sub command `aio runtime ip-list get`, that fetches the Adobe I/O Runtime egress IP allowlist from an IMS-authenticated backend service. Supports per-region filtering (--region), structured --json output, and an interactive or programmatic (--accept-terms --contact-email) terms-acceptance flow on first use.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Customers running App Builder / I/O Runtime workloads behind corporate egress firewalls need a self-service way to retrieve the current set of outbound IP addresses for their network allowlists. Today this information is only available via support tickets. Hence exposing it through the standard aio CLI removes that round-trip and provides a scriptable source of truth.


## How Has This Been Tested?

added new unit tests and verified via npm test
manually tested the workflow against the backend using different IMS orgs by `aio plugins link` the local cloned repo

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
