### PR TITLE
Add directive to use .detached for commands that time out

### DIFF
--- a/src/commands/runtime/sandbox/run.js
+++ b/src/commands/runtime/sandbox/run.js
@@ -179,7 +179,9 @@ class SandboxRun extends RuntimeBaseCommand {
           await this._handleExec(sandbox, trimmed)
         }
       } catch (err) {
-        this.log(`exec error: ${err.message || err}`)
+        const msg = err.message || String(err)
+        const hint = msg.includes('exceeded timeout') ? ' (use .detached for long-running commands)' : ''
+        this.log(`exec error: ${msg}${hint}`)
       }
     }
   }

--- a/test/commands/runtime/sandbox/run.test.js
+++ b/test/commands/runtime/sandbox/run.test.js
@@ -504,6 +504,16 @@ describe('run', () => {
     expect(stdout.output).toMatch('exec error: plain string error')
   })
 
+  test('REPL: timeout errors include a hint to use .detached', async () => {
+    readline.createInterface.mockReturnValue(makeRl(['sleep 35', 'exit']))
+    sandbox.exec.mockRejectedValueOnce(new Error("Command 'sleep 35' exceeded timeout of 30000ms"))
+
+    command.argv = []
+    await command.run()
+
+    expect(stdout.output).toMatch('exec error: Command \'sleep 35\' exceeded timeout of 30000ms (use .detached for long-running commands)')
+  })
+
   test('REPL: detached command starts in background and streams output', async () => {
     const rl = makeRl(['.detached npm run dev', 'exit'])
     readline.createInterface.mockReturnValue(rl)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

when a long-running command times out: exec error: Command 'sleep 35' exceeded timeout of 30000ms
Adding directive to use .detached in the error message. 


## Motivation and Context
https://jira.corp.adobe.com/browse/ACNA-4664

## How Has This Been Tested?

Yes, I manually tested it by linking the changes, creating a sandbox, and running a long-running command to verify the timeout behavior. I was able to reproduce the expected response:

`exec error: Command 'sleep 35' exceeded timeout of 30000ms (use .detached for long-running commands)`

I also ran `npm test`, and all tests passed.


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
