### PR TITLE
Add aio runtime sandbox exec command

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ $ aio runtime --help
 * [`aio runtime rule status NAME`](#aio-runtime-rule-status-name)
 * [`aio runtime rule update NAME TRIGGER ACTION`](#aio-runtime-rule-update-name-trigger-action)
 * [`aio runtime sandbox`](#aio-runtime-sandbox)
+* [`aio runtime sandbox exec`](#aio-runtime-sandbox-exec)
 * [`aio runtime sandbox run`](#aio-runtime-sandbox-run)
 * [`aio runtime trigger`](#aio-runtime-trigger)
 * [`aio runtime trigger create TRIGGERNAME`](#aio-runtime-trigger-create-triggername)
@@ -2183,6 +2184,73 @@ ALIASES
 ```
 
 _See code: [src/commands/runtime/sandbox/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/8.4.0/src/commands/runtime/sandbox/index.js)_
+
+## `aio runtime sandbox exec`
+
+[Alpha] Sandboxes are in a closed alpha. Your namespace must have
+
+```
+USAGE
+  $ aio runtime sandbox exec [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
+    [--help] [-n <value>] [-e <value>...] [-p <value>...] [--max-lifetime <value>] [--command-timeout <value>]
+    [--fail-fast]
+
+FLAGS
+  -e, --egress=<value>...        egress rule in host:port[:protocol][|METHOD:path] format, or "allow-all" (repeatable)
+  -i, --insecure                 bypass certificate check
+  -n, --name=<value>             [default: aio-sandbox] sandbox name
+  -p, --port=<value>...          Port to expose via a preview URL (repeatable)
+  -u, --auth                     [env: WHISK_AUTH] whisk auth
+  -v, --verbose                  Verbose output
+      --apihost                  [env: WHISK_APIHOST] whisk API host
+      --apiversion               [env: WHISK_APIVERSION] whisk API version
+      --cert                     client cert
+      --command-timeout=<value>  [default: 30000] per-command timeout in milliseconds
+      --debug=<value>            Debug level output
+      --fail-fast                stop execution when a command returns a non-zero exit code
+      --help                     Show help
+      --key                      client key
+      --max-lifetime=<value>     [default: 3600] maximum sandbox lifetime in seconds
+      --version                  Show version
+
+DESCRIPTION
+
+  [Alpha] Sandboxes are in a closed alpha. Your namespace must have
+  sandboxes enabled before you can use this command; contact Adobe to request
+  access.
+
+  Create a sandbox and run one or more commands non-interactively, then destroy it.
+
+  Provide a one-shot command after "--" and/or pipe a newline-separated list of
+  commands on stdin. When both are given, the one-shot command runs first,
+  followed by the piped commands in order.
+
+  Each command runs in a fresh process. Shell state (working directory, env
+  exports) does not persist between commands. Chain commands to work around
+  this: cd mydir && npm install
+
+  By default every command runs and the process exits with the last non-zero
+  exit code. Use --fail-fast to stop at the first failure. Each command is
+  capped at --command-timeout milliseconds (default 30000).
+
+  For an interactive session, use "aio runtime sandbox run" instead.
+
+ALIASES
+  $ aio rt sandbox exec
+
+EXAMPLES
+  $ aio runtime sandbox exec -- node --version
+
+  $ aio runtime sandbox exec < commands.txt
+
+  $ aio runtime sandbox exec -- node --version < commands.txt
+
+  $ aio runtime sandbox exec -e allow-all -p 5173 < commands.txt
+
+  $ aio runtime sandbox exec --fail-fast --command-timeout 120000 < commands.txt
+```
+
+_See code: [src/commands/runtime/sandbox/exec.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/8.4.0/src/commands/runtime/sandbox/exec.js)_
 
 ## `aio runtime sandbox run`
 

--- a/README.md
+++ b/README.md
@@ -1500,8 +1500,9 @@ Bind parameters to a package
 
 ```
 USAGE
-  $ aio runtime package bind PACKAGENAME BINDPACKAGENAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug
-    <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>] [-a <value>...] [-A <value>] [--json]
+  $ aio runtime package bind PACKAGENAME BINDPACKAGENAME [--cert <value>] [--key <value>] [--apiversion <value>]
+    [--apihost <value>] [-u <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>] [-a
+    <value>...] [-A <value>] [--json]
 
 FLAGS
   -A, --annotation-file=<value>  FILE containing annotation values in JSON format
@@ -1509,15 +1510,15 @@ FLAGS
   -a, --annotation=<value>...    annotation values in KEY VALUE format
   -i, --insecure                 bypass certificate check
   -p, --param=<value>...         parameters in key value pairs to be passed to the package
-  -u, --auth                     [env: WHISK_AUTH] whisk auth
+  -u, --auth=<value>             [env: WHISK_AUTH] whisk auth
   -v, --verbose                  Verbose output
-      --apihost                  [env: WHISK_APIHOST] whisk API host
-      --apiversion               [env: WHISK_APIVERSION] whisk API version
-      --cert                     client cert
+      --apihost=<value>          [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>       [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>             client cert
       --debug=<value>            Debug level output
       --help                     Show help
       --json                     output raw json
-      --key                      client key
+      --key=<value>              client key
       --version                  Show version
 
 DESCRIPTION
@@ -1537,8 +1538,9 @@ Creates a Package
 
 ```
 USAGE
-  $ aio runtime package create PACKAGENAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
-    [--version] [--help] [-p <value>...] [-P <value>] [--shared true|yes|false|no] [-a <value>...] [-A <value>] [--json]
+  $ aio runtime package create PACKAGENAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
+    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>] [--shared true|yes|false|no]
+    [-a <value>...] [-A <value>] [--json]
 
 FLAGS
   -A, --annotation-file=<value>  FILE containing annotation values in JSON format
@@ -1546,15 +1548,15 @@ FLAGS
   -a, --annotation=<value>...    annotation values in KEY VALUE format
   -i, --insecure                 bypass certificate check
   -p, --param=<value>...         parameters in key value pairs to be passed to the package
-  -u, --auth                     [env: WHISK_AUTH] whisk auth
+  -u, --auth=<value>             [env: WHISK_AUTH] whisk auth
   -v, --verbose                  Verbose output
-      --apihost                  [env: WHISK_APIHOST] whisk API host
-      --apiversion               [env: WHISK_APIVERSION] whisk API version
-      --cert                     client cert
+      --apihost=<value>          [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>       [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>             client cert
       --debug=<value>            Debug level output
       --help                     Show help
       --json                     output raw json
-      --key                      client key
+      --key=<value>              client key
       --shared=<option>          parameter to be passed to indicate whether package is shared or private
                                  <options: true|yes|false|no>
       --version                  Show version
@@ -1599,20 +1601,20 @@ Retrieves a Package
 
 ```
 USAGE
-  $ aio runtime package get PACKAGENAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
-    [--version] [--help]
+  $ aio runtime package get PACKAGENAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
+    <value>] [-i] [--debug <value>] [-v] [--version] [--help]
 
 FLAGS
-  -i, --insecure       bypass certificate check
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --key            client key
-      --version        Show version
+  -i, --insecure            bypass certificate check
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --key=<value>         client key
+      --version             Show version
 
 DESCRIPTION
   Retrieves a Package
@@ -1631,26 +1633,26 @@ Lists all the Packages
 
 ```
 USAGE
-  $ aio runtime package list [NAMESPACE] [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
-    [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio runtime package list [NAMESPACE] [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
+    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of packages
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  only return LIMIT number of packages (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   exclude the first SKIP number of packages from the result
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of packages
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       only return LIMIT number of packages (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        exclude the first SKIP number of packages from the result
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Lists all the Packages
@@ -1673,8 +1675,9 @@ Updates a Package
 
 ```
 USAGE
-  $ aio runtime package update PACKAGENAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
-    [--version] [--help] [-p <value>...] [-P <value>] [--shared true|yes|false|no] [-a <value>...] [-A <value>] [--json]
+  $ aio runtime package update PACKAGENAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
+    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>] [--shared true|yes|false|no]
+    [-a <value>...] [-A <value>] [--json]
 
 FLAGS
   -A, --annotation-file=<value>  FILE containing annotation values in JSON format
@@ -1682,15 +1685,15 @@ FLAGS
   -a, --annotation=<value>...    annotation values in KEY VALUE format
   -i, --insecure                 bypass certificate check
   -p, --param=<value>...         parameters in key value pairs to be passed to the package
-  -u, --auth                     [env: WHISK_AUTH] whisk auth
+  -u, --auth=<value>             [env: WHISK_AUTH] whisk auth
   -v, --verbose                  Verbose output
-      --apihost                  [env: WHISK_APIHOST] whisk API host
-      --apiversion               [env: WHISK_APIVERSION] whisk API version
-      --cert                     client cert
+      --apihost=<value>          [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>       [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>             client cert
       --debug=<value>            Debug level output
       --help                     Show help
       --json                     output raw json
-      --key                      client key
+      --key=<value>              client key
       --shared=<option>          parameter to be passed to indicate whether package is shared or private
                                  <options: true|yes|false|no>
       --version                  Show version
@@ -2017,23 +2020,23 @@ Retrieves a Rule
 
 ```
 USAGE
-  $ aio runtime rule get NAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>]
-    [-i] [--debug <value>] [-v] [--version] [--help]
+  $ aio runtime rule get NAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
+    [--help]
 
 ARGUMENTS
   NAME  Name of the rule
 
 FLAGS
-  -i, --insecure            bypass certificate check
-  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
-  -v, --verbose             Verbose output
-      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>        client cert
-      --debug=<value>       Debug level output
-      --help                Show help
-      --key=<value>         client key
-      --version             Show version
+  -i, --insecure       bypass certificate check
+  -u, --auth           [env: WHISK_AUTH] whisk auth
+  -v, --verbose        Verbose output
+      --apihost        [env: WHISK_APIHOST] whisk API host
+      --apiversion     [env: WHISK_APIVERSION] whisk API version
+      --cert           client cert
+      --debug=<value>  Debug level output
+      --help           Show help
+      --key            client key
+      --version        Show version
 
 DESCRIPTION
   Retrieves a Rule
@@ -2050,26 +2053,26 @@ Retrieves a list of Rules
 
 ```
 USAGE
-  $ aio runtime rule list [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
-    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio runtime rule list [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
+    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count               show only the total number of rules
-  -i, --insecure            bypass certificate check
-  -l, --limit=<value>       Limit number of rules returned (min: 0, max: 50)
-  -n, --name                sort results by name
-  -s, --skip=<value>        Skip number of rules returned
-  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
-  -v, --verbose             Verbose output
-      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>        client cert
-      --debug=<value>       Debug level output
-      --help                Show help
-      --json                output raw json
-      --key=<value>         client key
-      --name-sort           sort results by name
-      --version             Show version
+  -c, --count          show only the total number of rules
+  -i, --insecure       bypass certificate check
+  -l, --limit=<value>  Limit number of rules returned (min: 0, max: 50)
+  -n, --name           sort results by name
+  -s, --skip=<value>   Skip number of rules returned
+  -u, --auth           [env: WHISK_AUTH] whisk auth
+  -v, --verbose        Verbose output
+      --apihost        [env: WHISK_APIHOST] whisk API host
+      --apiversion     [env: WHISK_APIVERSION] whisk API version
+      --cert           client cert
+      --debug=<value>  Debug level output
+      --help           Show help
+      --json           output raw json
+      --key            client key
+      --name-sort      sort results by name
+      --version        Show version
 
 DESCRIPTION
   Retrieves a list of Rules
@@ -2088,23 +2091,23 @@ Gets the status of a rule
 
 ```
 USAGE
-  $ aio runtime rule status NAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>]
-    [-i] [--debug <value>] [-v] [--version] [--help]
+  $ aio runtime rule status NAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
+    [--help]
 
 ARGUMENTS
   NAME  Name of the rule
 
 FLAGS
-  -i, --insecure            bypass certificate check
-  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
-  -v, --verbose             Verbose output
-      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>        client cert
-      --debug=<value>       Debug level output
-      --help                Show help
-      --key=<value>         client key
-      --version             Show version
+  -i, --insecure       bypass certificate check
+  -u, --auth           [env: WHISK_AUTH] whisk auth
+  -v, --verbose        Verbose output
+      --apihost        [env: WHISK_APIHOST] whisk API host
+      --apiversion     [env: WHISK_APIVERSION] whisk API version
+      --cert           client cert
+      --debug=<value>  Debug level output
+      --help           Show help
+      --key            client key
+      --version        Show version
 
 DESCRIPTION
   Gets the status of a rule
@@ -2188,28 +2191,29 @@ _See code: [src/commands/runtime/sandbox/index.js](https://github.com/adobe/aio-
 
 ```
 USAGE
-  $ aio runtime sandbox exec [COMMAND] [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
-    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-n <value>] [-e <value>...] [-p <value>...]
-    [--max-lifetime <value>] [--command-timeout <value>] [--fail-fast]
+  $ aio runtime sandbox exec [COMMAND] [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
+    [--version] [--help] [-n <value>] [-e <value>...] [-p <value>...] [--max-lifetime <value>] [--command-timeout
+    <value>] [--fail-fast] [-f <value>]
 
 ARGUMENTS
   [COMMAND]  command to run in the sandbox (quote multi-word commands)
 
 FLAGS
   -e, --egress=<value>...        egress rule in host:port[:protocol][|METHOD:path] format, or "allow-all" (repeatable)
+  -f, --file=<value>             path to a file with a newline-separated list of commands to run
   -i, --insecure                 bypass certificate check
   -n, --name=<value>             [default: aio-sandbox] sandbox name
   -p, --port=<value>...          Port to expose via a preview URL (repeatable)
-  -u, --auth=<value>             [env: WHISK_AUTH] whisk auth
+  -u, --auth                     [env: WHISK_AUTH] whisk auth
   -v, --verbose                  Verbose output
-      --apihost=<value>          [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>       [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>             client cert
+      --apihost                  [env: WHISK_APIHOST] whisk API host
+      --apiversion               [env: WHISK_APIVERSION] whisk API version
+      --cert                     client cert
       --command-timeout=<value>  [default: 30000] per-command timeout in milliseconds
       --debug=<value>            Debug level output
       --fail-fast                stop execution when a command returns a non-zero exit code
       --help                     Show help
-      --key=<value>              client key
+      --key                      client key
       --max-lifetime=<value>     [default: 3600] maximum sandbox lifetime in seconds
       --version                  Show version
 
@@ -2221,9 +2225,9 @@ DESCRIPTION
 
   Create a sandbox and run one or more commands non-interactively, then destroy it.
 
-  Provide a one-shot command as a quoted argument and/or pipe a newline-separated
-  list of commands on stdin. When both are given, the one-shot command runs first,
-  followed by the piped commands in order.
+  Provide a one-shot command as a quoted argument and/or a newline-separated list
+  of commands via --file. When both are given, the one-shot command runs first,
+  followed by the list in order.
 
   Each command runs in a fresh process. Shell state (working directory, env
   exports) does not persist between commands. Chain commands to work around
@@ -2241,13 +2245,13 @@ ALIASES
 EXAMPLES
   $ aio runtime sandbox exec "node --version"
 
-  $ aio runtime sandbox exec < commands.txt
+  $ aio runtime sandbox exec --file commands.txt
 
-  $ aio runtime sandbox exec "node --version" < commands.txt
+  $ aio runtime sandbox exec "node --version" --file commands.txt
 
-  $ aio runtime sandbox exec -e allow-all -p 5173 < commands.txt
+  $ aio runtime sandbox exec -e allow-all -p 5173 --file commands.txt
 
-  $ aio runtime sandbox exec --fail-fast --command-timeout 120000 < commands.txt
+  $ aio runtime sandbox exec --fail-fast --command-timeout 120000 --file commands.txt
 ```
 
 _See code: [src/commands/runtime/sandbox/exec.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/8.4.0/src/commands/runtime/sandbox/exec.js)_
@@ -2258,22 +2262,22 @@ _See code: [src/commands/runtime/sandbox/exec.js](https://github.com/adobe/aio-c
 
 ```
 USAGE
-  $ aio runtime sandbox run [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
-    [--debug <value>] [-v] [--version] [--help] [-n <value>] [-e <value>...] [-p <value>...] [--max-lifetime <value>]
+  $ aio runtime sandbox run [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
+    [--help] [-n <value>] [-e <value>...] [-p <value>...] [--max-lifetime <value>]
 
 FLAGS
   -e, --egress=<value>...     egress rule in host:port[:protocol][|METHOD:path] format, or "allow-all" (repeatable)
   -i, --insecure              bypass certificate check
   -n, --name=<value>          [default: aio-sandbox] sandbox name
   -p, --port=<value>...       Port to expose via a preview URL (repeatable)
-  -u, --auth=<value>          [env: WHISK_AUTH] whisk auth
+  -u, --auth                  [env: WHISK_AUTH] whisk auth
   -v, --verbose               Verbose output
-      --apihost=<value>       [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>    [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>          client cert
+      --apihost               [env: WHISK_APIHOST] whisk API host
+      --apiversion            [env: WHISK_APIVERSION] whisk API version
+      --cert                  client cert
       --debug=<value>         Debug level output
       --help                  Show help
-      --key=<value>           client key
+      --key                   client key
       --max-lifetime=<value>  [default: 3600] maximum sandbox lifetime in seconds
       --version               Show version
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ aio runtime --help
 * [`aio runtime rule status NAME`](#aio-runtime-rule-status-name)
 * [`aio runtime rule update NAME TRIGGER ACTION`](#aio-runtime-rule-update-name-trigger-action)
 * [`aio runtime sandbox`](#aio-runtime-sandbox)
-* [`aio runtime sandbox exec`](#aio-runtime-sandbox-exec)
+* [`aio runtime sandbox exec [COMMAND]`](#aio-runtime-sandbox-exec-command)
 * [`aio runtime sandbox run`](#aio-runtime-sandbox-run)
 * [`aio runtime trigger`](#aio-runtime-trigger)
 * [`aio runtime trigger create TRIGGERNAME`](#aio-runtime-trigger-create-triggername)
@@ -1500,9 +1500,8 @@ Bind parameters to a package
 
 ```
 USAGE
-  $ aio runtime package bind PACKAGENAME BINDPACKAGENAME [--cert <value>] [--key <value>] [--apiversion <value>]
-    [--apihost <value>] [-u <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>] [-a
-    <value>...] [-A <value>] [--json]
+  $ aio runtime package bind PACKAGENAME BINDPACKAGENAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug
+    <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>] [-a <value>...] [-A <value>] [--json]
 
 FLAGS
   -A, --annotation-file=<value>  FILE containing annotation values in JSON format
@@ -1510,15 +1509,15 @@ FLAGS
   -a, --annotation=<value>...    annotation values in KEY VALUE format
   -i, --insecure                 bypass certificate check
   -p, --param=<value>...         parameters in key value pairs to be passed to the package
-  -u, --auth=<value>             [env: WHISK_AUTH] whisk auth
+  -u, --auth                     [env: WHISK_AUTH] whisk auth
   -v, --verbose                  Verbose output
-      --apihost=<value>          [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>       [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>             client cert
+      --apihost                  [env: WHISK_APIHOST] whisk API host
+      --apiversion               [env: WHISK_APIVERSION] whisk API version
+      --cert                     client cert
       --debug=<value>            Debug level output
       --help                     Show help
       --json                     output raw json
-      --key=<value>              client key
+      --key                      client key
       --version                  Show version
 
 DESCRIPTION
@@ -1538,9 +1537,8 @@ Creates a Package
 
 ```
 USAGE
-  $ aio runtime package create PACKAGENAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
-    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>] [--shared true|yes|false|no]
-    [-a <value>...] [-A <value>] [--json]
+  $ aio runtime package create PACKAGENAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
+    [--version] [--help] [-p <value>...] [-P <value>] [--shared true|yes|false|no] [-a <value>...] [-A <value>] [--json]
 
 FLAGS
   -A, --annotation-file=<value>  FILE containing annotation values in JSON format
@@ -1548,15 +1546,15 @@ FLAGS
   -a, --annotation=<value>...    annotation values in KEY VALUE format
   -i, --insecure                 bypass certificate check
   -p, --param=<value>...         parameters in key value pairs to be passed to the package
-  -u, --auth=<value>             [env: WHISK_AUTH] whisk auth
+  -u, --auth                     [env: WHISK_AUTH] whisk auth
   -v, --verbose                  Verbose output
-      --apihost=<value>          [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>       [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>             client cert
+      --apihost                  [env: WHISK_APIHOST] whisk API host
+      --apiversion               [env: WHISK_APIVERSION] whisk API version
+      --cert                     client cert
       --debug=<value>            Debug level output
       --help                     Show help
       --json                     output raw json
-      --key=<value>              client key
+      --key                      client key
       --shared=<option>          parameter to be passed to indicate whether package is shared or private
                                  <options: true|yes|false|no>
       --version                  Show version
@@ -1601,20 +1599,20 @@ Retrieves a Package
 
 ```
 USAGE
-  $ aio runtime package get PACKAGENAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
-    <value>] [-i] [--debug <value>] [-v] [--version] [--help]
+  $ aio runtime package get PACKAGENAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
+    [--version] [--help]
 
 FLAGS
-  -i, --insecure            bypass certificate check
-  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
-  -v, --verbose             Verbose output
-      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>        client cert
-      --debug=<value>       Debug level output
-      --help                Show help
-      --key=<value>         client key
-      --version             Show version
+  -i, --insecure       bypass certificate check
+  -u, --auth           [env: WHISK_AUTH] whisk auth
+  -v, --verbose        Verbose output
+      --apihost        [env: WHISK_APIHOST] whisk API host
+      --apiversion     [env: WHISK_APIVERSION] whisk API version
+      --cert           client cert
+      --debug=<value>  Debug level output
+      --help           Show help
+      --key            client key
+      --version        Show version
 
 DESCRIPTION
   Retrieves a Package
@@ -1633,26 +1631,26 @@ Lists all the Packages
 
 ```
 USAGE
-  $ aio runtime package list [NAMESPACE] [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
-    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio runtime package list [NAMESPACE] [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
+    [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count               show only the total number of packages
-  -i, --insecure            bypass certificate check
-  -l, --limit=<value>       only return LIMIT number of packages (min: 0, max: 50)
-  -n, --name                sort results by name
-  -s, --skip=<value>        exclude the first SKIP number of packages from the result
-  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
-  -v, --verbose             Verbose output
-      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>        client cert
-      --debug=<value>       Debug level output
-      --help                Show help
-      --json                output raw json
-      --key=<value>         client key
-      --name-sort           sort results by name
-      --version             Show version
+  -c, --count          show only the total number of packages
+  -i, --insecure       bypass certificate check
+  -l, --limit=<value>  only return LIMIT number of packages (min: 0, max: 50)
+  -n, --name           sort results by name
+  -s, --skip=<value>   exclude the first SKIP number of packages from the result
+  -u, --auth           [env: WHISK_AUTH] whisk auth
+  -v, --verbose        Verbose output
+      --apihost        [env: WHISK_APIHOST] whisk API host
+      --apiversion     [env: WHISK_APIVERSION] whisk API version
+      --cert           client cert
+      --debug=<value>  Debug level output
+      --help           Show help
+      --json           output raw json
+      --key            client key
+      --name-sort      sort results by name
+      --version        Show version
 
 DESCRIPTION
   Lists all the Packages
@@ -1675,9 +1673,8 @@ Updates a Package
 
 ```
 USAGE
-  $ aio runtime package update PACKAGENAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
-    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>] [--shared true|yes|false|no]
-    [-a <value>...] [-A <value>] [--json]
+  $ aio runtime package update PACKAGENAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
+    [--version] [--help] [-p <value>...] [-P <value>] [--shared true|yes|false|no] [-a <value>...] [-A <value>] [--json]
 
 FLAGS
   -A, --annotation-file=<value>  FILE containing annotation values in JSON format
@@ -1685,15 +1682,15 @@ FLAGS
   -a, --annotation=<value>...    annotation values in KEY VALUE format
   -i, --insecure                 bypass certificate check
   -p, --param=<value>...         parameters in key value pairs to be passed to the package
-  -u, --auth=<value>             [env: WHISK_AUTH] whisk auth
+  -u, --auth                     [env: WHISK_AUTH] whisk auth
   -v, --verbose                  Verbose output
-      --apihost=<value>          [env: WHISK_APIHOST] whisk API host
-      --apiversion=<value>       [env: WHISK_APIVERSION] whisk API version
-      --cert=<value>             client cert
+      --apihost                  [env: WHISK_APIHOST] whisk API host
+      --apiversion               [env: WHISK_APIVERSION] whisk API version
+      --cert                     client cert
       --debug=<value>            Debug level output
       --help                     Show help
       --json                     output raw json
-      --key=<value>              client key
+      --key                      client key
       --shared=<option>          parameter to be passed to indicate whether package is shared or private
                                  <options: true|yes|false|no>
       --version                  Show version
@@ -2020,23 +2017,23 @@ Retrieves a Rule
 
 ```
 USAGE
-  $ aio runtime rule get NAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help]
+  $ aio runtime rule get NAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>]
+    [-i] [--debug <value>] [-v] [--version] [--help]
 
 ARGUMENTS
   NAME  Name of the rule
 
 FLAGS
-  -i, --insecure       bypass certificate check
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --key            client key
-      --version        Show version
+  -i, --insecure            bypass certificate check
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --key=<value>         client key
+      --version             Show version
 
 DESCRIPTION
   Retrieves a Rule
@@ -2053,26 +2050,26 @@ Retrieves a list of Rules
 
 ```
 USAGE
-  $ aio runtime rule list [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio runtime rule list [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of rules
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  Limit number of rules returned (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   Skip number of rules returned
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of rules
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       Limit number of rules returned (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        Skip number of rules returned
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Retrieves a list of Rules
@@ -2091,23 +2088,23 @@ Gets the status of a rule
 
 ```
 USAGE
-  $ aio runtime rule status NAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help]
+  $ aio runtime rule status NAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>]
+    [-i] [--debug <value>] [-v] [--version] [--help]
 
 ARGUMENTS
   NAME  Name of the rule
 
 FLAGS
-  -i, --insecure       bypass certificate check
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --key            client key
-      --version        Show version
+  -i, --insecure            bypass certificate check
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --key=<value>         client key
+      --version             Show version
 
 DESCRIPTION
   Gets the status of a rule
@@ -2185,31 +2182,34 @@ ALIASES
 
 _See code: [src/commands/runtime/sandbox/index.js](https://github.com/adobe/aio-cli-plugin-runtime/blob/8.4.0/src/commands/runtime/sandbox/index.js)_
 
-## `aio runtime sandbox exec`
+## `aio runtime sandbox exec [COMMAND]`
 
 [Alpha] Sandboxes are in a closed alpha. Your namespace must have
 
 ```
 USAGE
-  $ aio runtime sandbox exec [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-n <value>] [-e <value>...] [-p <value>...] [--max-lifetime <value>] [--command-timeout <value>]
-    [--fail-fast]
+  $ aio runtime sandbox exec [COMMAND] [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
+    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-n <value>] [-e <value>...] [-p <value>...]
+    [--max-lifetime <value>] [--command-timeout <value>] [--fail-fast]
+
+ARGUMENTS
+  [COMMAND]  command to run in the sandbox (quote multi-word commands)
 
 FLAGS
   -e, --egress=<value>...        egress rule in host:port[:protocol][|METHOD:path] format, or "allow-all" (repeatable)
   -i, --insecure                 bypass certificate check
   -n, --name=<value>             [default: aio-sandbox] sandbox name
   -p, --port=<value>...          Port to expose via a preview URL (repeatable)
-  -u, --auth                     [env: WHISK_AUTH] whisk auth
+  -u, --auth=<value>             [env: WHISK_AUTH] whisk auth
   -v, --verbose                  Verbose output
-      --apihost                  [env: WHISK_APIHOST] whisk API host
-      --apiversion               [env: WHISK_APIVERSION] whisk API version
-      --cert                     client cert
+      --apihost=<value>          [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>       [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>             client cert
       --command-timeout=<value>  [default: 30000] per-command timeout in milliseconds
       --debug=<value>            Debug level output
       --fail-fast                stop execution when a command returns a non-zero exit code
       --help                     Show help
-      --key                      client key
+      --key=<value>              client key
       --max-lifetime=<value>     [default: 3600] maximum sandbox lifetime in seconds
       --version                  Show version
 
@@ -2221,8 +2221,8 @@ DESCRIPTION
 
   Create a sandbox and run one or more commands non-interactively, then destroy it.
 
-  Provide a one-shot command after "--" and/or pipe a newline-separated list of
-  commands on stdin. When both are given, the one-shot command runs first,
+  Provide a one-shot command as a quoted argument and/or pipe a newline-separated
+  list of commands on stdin. When both are given, the one-shot command runs first,
   followed by the piped commands in order.
 
   Each command runs in a fresh process. Shell state (working directory, env
@@ -2239,11 +2239,11 @@ ALIASES
   $ aio rt sandbox exec
 
 EXAMPLES
-  $ aio runtime sandbox exec -- node --version
+  $ aio runtime sandbox exec "node --version"
 
   $ aio runtime sandbox exec < commands.txt
 
-  $ aio runtime sandbox exec -- node --version < commands.txt
+  $ aio runtime sandbox exec "node --version" < commands.txt
 
   $ aio runtime sandbox exec -e allow-all -p 5173 < commands.txt
 
@@ -2258,22 +2258,22 @@ _See code: [src/commands/runtime/sandbox/exec.js](https://github.com/adobe/aio-c
 
 ```
 USAGE
-  $ aio runtime sandbox run [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-n <value>] [-e <value>...] [-p <value>...] [--max-lifetime <value>]
+  $ aio runtime sandbox run [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-n <value>] [-e <value>...] [-p <value>...] [--max-lifetime <value>]
 
 FLAGS
   -e, --egress=<value>...     egress rule in host:port[:protocol][|METHOD:path] format, or "allow-all" (repeatable)
   -i, --insecure              bypass certificate check
   -n, --name=<value>          [default: aio-sandbox] sandbox name
   -p, --port=<value>...       Port to expose via a preview URL (repeatable)
-  -u, --auth                  [env: WHISK_AUTH] whisk auth
+  -u, --auth=<value>          [env: WHISK_AUTH] whisk auth
   -v, --verbose               Verbose output
-      --apihost               [env: WHISK_APIHOST] whisk API host
-      --apiversion            [env: WHISK_APIVERSION] whisk API version
-      --cert                  client cert
+      --apihost=<value>       [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>    [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>          client cert
       --debug=<value>         Debug level output
       --help                  Show help
-      --key                   client key
+      --key=<value>           client key
       --max-lifetime=<value>  [default: 3600] maximum sandbox lifetime in seconds
       --version               Show version
 

--- a/src/commands/runtime/sandbox/exec.js
+++ b/src/commands/runtime/sandbox/exec.js
@@ -1,0 +1,217 @@
+/*
+Copyright 2026 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Sandbox } = require('@adobe/aio-lib-sandbox')
+const { Flags } = require('@oclif/core')
+const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
+const {
+  buildNetworkPolicy,
+  parsePortFlags,
+  parseEgressFlags,
+  splitArgvAtDoubleDash,
+  buildCommandList,
+  shellQuote
+} = require('../../../sandbox-helpers')
+
+const COMMAND_TIMEOUT_MS = 30000
+
+class SandboxExec extends RuntimeBaseCommand {
+  async init () {
+    const rawArgv = [...this.argv]
+    const { cliArgs } = splitArgvAtDoubleDash(rawArgv)
+
+    await this.parse(SandboxExec, cliArgs)
+    this.argv = rawArgv
+  }
+
+  async run () {
+    const { cliArgs, commandArgs } = splitArgvAtDoubleDash(this.argv)
+    const { flags } = await this.parse(SandboxExec, cliArgs)
+
+    const stdinText = process.stdin.isTTY === true ? '' : await this._readStdin()
+    const commands = buildCommandList(commandArgs, stdinText)
+
+    if (commands.length === 0) {
+      this._failUsage('No commands to run. Pass a command after "--" and/or pipe a newline-separated list on stdin. For an interactive session use "aio runtime sandbox run".')
+      return
+    }
+
+    let sandbox
+    try {
+      const policy = buildNetworkPolicy(flags.egress)
+      const ports = parsePortFlags(flags.port)
+      const options = await this.getOptions()
+
+      this.log('\nCreating sandbox...')
+      sandbox = await Sandbox.create({
+        apiHost: options.apihost,
+        namespace: options.namespace,
+        auth: options.api_key,
+        name: flags.name,
+        maxLifetime: flags['max-lifetime'],
+        envs: {},
+        ...(ports && { ports }),
+        ...(policy && { policy })
+      })
+      this.log(`Created: ${sandbox.id}`)
+
+      this._logPolicy(policy)
+      await this._logPreviewUrls(sandbox, ports)
+
+      await this._runCommands(sandbox, commands, flags)
+    } catch (err) {
+      await this.handleError('failed to exec in sandbox', err)
+    } finally {
+      if (sandbox) {
+        try {
+          await sandbox.destroy()
+          this.log('Sandbox destroyed.')
+        } catch (destroyErr) {
+          this.log(`failed to destroy sandbox: ${destroyErr.message || destroyErr}`)
+        }
+      }
+    }
+  }
+
+  _readStdin () {
+    return new Promise((resolve, reject) => {
+      const chunks = []
+      process.stdin.on('data', chunk => chunks.push(chunk))
+      process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString()))
+      process.stdin.on('error', reject)
+    })
+  }
+
+  _failUsage (message) {
+    process.stderr.write(`${message}\n`)
+    process.exitCode = 2
+  }
+
+  _logPolicy (policy) {
+    if (!policy) {
+      this.log('Network policy: default-deny (DNS + NATS only)')
+      return
+    }
+    if (policy.network.egress === 'allow-all') {
+      this.log('Network policy: allow-all egress')
+      return
+    }
+    this.log('Network policy: custom egress')
+    policy.network.egress.forEach(rule => {
+      const proto = rule.protocol || 'TCP'
+      const l7 = rule.rules ? ' ' + rule.rules.map(r => `${r.methods.join(',')}:${r.pathPattern}`).join(' ') : ''
+      this.log(`  - ${rule.host}:${rule.port} (${proto})${l7}`)
+    })
+  }
+
+  async _logPreviewUrls (sandbox, ports) {
+    if (!ports) {
+      return
+    }
+
+    this.log('Preview URLs:')
+    for (const port of ports) {
+      this.log(`  - ${port}: ${await sandbox.getUrl(port)}`)
+    }
+  }
+
+  async _runCommands (sandbox, commands, flags) {
+    const timeout = flags['command-timeout']
+    for (const cmd of commands) {
+      this.log(`\n$ ${cmd}`)
+      const result = await sandbox.exec(cmd, { timeout })
+      if (result.stdout) process.stdout.write(result.stdout)
+      if (result.stderr) process.stderr.write(result.stderr)
+      this.log(`[exit: ${result.exitCode}]`)
+
+      if (result.exitCode !== 0) {
+        process.exitCode = result.exitCode
+        if (flags['fail-fast']) {
+          this.log('Stopping: command exited non-zero (--fail-fast).')
+          return
+        }
+      }
+    }
+  }
+}
+
+SandboxExec.description = `
+[Alpha] Sandboxes are in a closed alpha. Your namespace must have
+sandboxes enabled before you can use this command; contact Adobe to request
+access.
+
+Create a sandbox and run one or more commands non-interactively, then destroy it.
+
+Provide a one-shot command after "--" and/or pipe a newline-separated list of
+commands on stdin. When both are given, the one-shot command runs first,
+followed by the piped commands in order.
+
+Each command runs in a fresh process. Shell state (working directory, env
+exports) does not persist between commands. Chain commands to work around
+this: cd mydir && npm install
+
+By default every command runs and the process exits with the last non-zero
+exit code. Use --fail-fast to stop at the first failure. Each command is
+capped at --command-timeout milliseconds (default 30000).
+
+For an interactive session, use "aio runtime sandbox run" instead.`
+
+SandboxExec.flags = {
+  ...RuntimeBaseCommand.flags,
+  name: Flags.string({
+    char: 'n',
+    description: 'sandbox name',
+    default: 'aio-sandbox'
+  }),
+  egress: Flags.string({
+    char: 'e',
+    description: 'egress rule in host:port[:protocol][|METHOD:path] format, or "allow-all" (repeatable)',
+    multiple: true
+  }),
+  port: Flags.string({
+    char: 'p',
+    description: 'Port to expose via a preview URL (repeatable)',
+    multiple: true
+  }),
+  'max-lifetime': Flags.integer({
+    description: 'maximum sandbox lifetime in seconds',
+    default: 3600
+  }),
+  'command-timeout': Flags.integer({
+    description: 'per-command timeout in milliseconds',
+    default: COMMAND_TIMEOUT_MS
+  }),
+  'fail-fast': Flags.boolean({
+    description: 'stop execution when a command returns a non-zero exit code',
+    default: false
+  })
+}
+
+SandboxExec.examples = [
+  '<%= config.bin %> <%= command.id %> -- node --version',
+  '<%= config.bin %> <%= command.id %> < commands.txt',
+  '<%= config.bin %> <%= command.id %> -- node --version < commands.txt',
+  '<%= config.bin %> <%= command.id %> -e allow-all -p 5173 < commands.txt',
+  '<%= config.bin %> <%= command.id %> --fail-fast --command-timeout 120000 < commands.txt'
+]
+
+SandboxExec.aliases = ['rt:sandbox:exec']
+
+// exposed for testing
+SandboxExec.parseEgressFlags = parseEgressFlags
+SandboxExec.parsePortFlags = parsePortFlags
+SandboxExec.buildNetworkPolicy = buildNetworkPolicy
+SandboxExec.splitArgvAtDoubleDash = splitArgvAtDoubleDash
+SandboxExec.buildCommandList = buildCommandList
+SandboxExec.shellQuote = shellQuote
+
+module.exports = SandboxExec

--- a/src/commands/runtime/sandbox/exec.js
+++ b/src/commands/runtime/sandbox/exec.js
@@ -26,9 +26,15 @@ const DEFAULT_COMMAND_TIMEOUT_MS = 30000
 
 class SandboxExec extends RuntimeBaseCommand {
   async run () {
+    // Start reading piped stdin before the async parse below: on some platforms
+    // (notably Windows PowerShell) the piped data and EOF arrive during the
+    // parse, and attaching listeners afterwards would miss them.
+    const stdinPromise = process.stdin.isTTY === true ? Promise.resolve('') : this._readStdin()
+    stdinPromise.catch(() => {}) // parse may reject first; avoid an unhandled rejection
+
     const { args, flags } = await this.parse(SandboxExec)
 
-    const stdinText = process.stdin.isTTY === true ? '' : await this._readStdin()
+    const stdinText = await stdinPromise
     const commands = buildCommandList(args.command, stdinText)
 
     if (commands.length === 0) {

--- a/src/commands/runtime/sandbox/exec.js
+++ b/src/commands/runtime/sandbox/exec.js
@@ -10,6 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const fs = require('node:fs')
 const { Sandbox } = require('@adobe/aio-lib-sandbox')
 const { Args, Flags } = require('@oclif/core')
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
@@ -26,21 +27,21 @@ const DEFAULT_COMMAND_TIMEOUT_MS = 30000
 
 class SandboxExec extends RuntimeBaseCommand {
   async run () {
-    // Start reading piped stdin before the async parse below: on some platforms
-    // (notably Windows PowerShell) the piped data and EOF arrive during the
-    // parse, and attaching listeners afterwards would miss them.
-    const stdinPromise = process.stdin.isTTY === true ? Promise.resolve('') : this._readStdin()
-    // Avoid an unhandled rejection if parse rejects before we await this; a real
-    // stdin read error still surfaces at the `await stdinPromise` below.
-    stdinPromise.catch(() => {})
-
     const { args, flags } = await this.parse(SandboxExec)
 
-    const stdinText = await stdinPromise
-    const commands = buildCommandList(args.command, stdinText)
+    let listText = ''
+    if (flags.file) {
+      try {
+        listText = this._readFile(flags.file)
+      } catch (err) {
+        this._failUsage(`Cannot read --file "${flags.file}": ${err.message || err}`)
+        return
+      }
+    }
+    const commands = buildCommandList(args.command, listText)
 
     if (commands.length === 0) {
-      this._failUsage('No commands to run. Pass a quoted command (e.g. \'node --version\') and/or pipe a newline-separated list on stdin. For an interactive session use "aio runtime sandbox run".')
+      this._failUsage('No commands to run. Pass a quoted command (e.g. \'node --version\') and/or a command list with --file. For an interactive session use "aio runtime sandbox run".')
       return
     }
 
@@ -81,30 +82,8 @@ class SandboxExec extends RuntimeBaseCommand {
     }
   }
 
-  _readStdin () {
-    return new Promise((resolve, reject) => {
-      const chunks = []
-      const onData = chunk => chunks.push(chunk)
-      const onEnd = () => {
-        teardown()
-        resolve(Buffer.concat(chunks).toString())
-      }
-      const onError = err => {
-        teardown()
-        reject(err)
-      }
-      /**
-       * Detach all stdin listeners so repeated calls don't leak handlers.
-       */
-      function teardown () {
-        process.stdin.removeListener('data', onData)
-        process.stdin.removeListener('end', onEnd)
-        process.stdin.removeListener('error', onError)
-      }
-      process.stdin.on('data', onData)
-      process.stdin.on('end', onEnd)
-      process.stdin.on('error', onError)
-    })
+  _readFile (filePath) {
+    return fs.readFileSync(filePath, 'utf8')
   }
 
   _failUsage (message) {
@@ -139,9 +118,9 @@ access.
 
 Create a sandbox and run one or more commands non-interactively, then destroy it.
 
-Provide a one-shot command as a quoted argument and/or pipe a newline-separated
-list of commands on stdin. When both are given, the one-shot command runs first,
-followed by the piped commands in order.
+Provide a one-shot command as a quoted argument and/or a newline-separated list
+of commands via --file. When both are given, the one-shot command runs first,
+followed by the list in order.
 
 Each command runs in a fresh process. Shell state (working directory, env
 exports) does not persist between commands. Chain commands to work around
@@ -185,6 +164,10 @@ SandboxExec.flags = {
   'fail-fast': Flags.boolean({
     description: 'stop execution when a command returns a non-zero exit code',
     default: false
+  }),
+  file: Flags.string({
+    char: 'f',
+    description: 'path to a file with a newline-separated list of commands to run'
   })
 }
 
@@ -197,10 +180,10 @@ SandboxExec.args = {
 
 SandboxExec.examples = [
   '<%= config.bin %> <%= command.id %> "node --version"',
-  '<%= config.bin %> <%= command.id %> < commands.txt',
-  '<%= config.bin %> <%= command.id %> "node --version" < commands.txt',
-  '<%= config.bin %> <%= command.id %> -e allow-all -p 5173 < commands.txt',
-  '<%= config.bin %> <%= command.id %> --fail-fast --command-timeout 120000 < commands.txt'
+  '<%= config.bin %> <%= command.id %> --file commands.txt',
+  '<%= config.bin %> <%= command.id %> "node --version" --file commands.txt',
+  '<%= config.bin %> <%= command.id %> -e allow-all -p 5173 --file commands.txt',
+  '<%= config.bin %> <%= command.id %> --fail-fast --command-timeout 120000 --file commands.txt'
 ]
 
 SandboxExec.aliases = ['rt:sandbox:exec']

--- a/src/commands/runtime/sandbox/exec.js
+++ b/src/commands/runtime/sandbox/exec.js
@@ -76,9 +76,26 @@ class SandboxExec extends RuntimeBaseCommand {
   _readStdin () {
     return new Promise((resolve, reject) => {
       const chunks = []
-      process.stdin.on('data', chunk => chunks.push(chunk))
-      process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString()))
-      process.stdin.on('error', reject)
+      const onData = chunk => chunks.push(chunk)
+      const onEnd = () => {
+        teardown()
+        resolve(Buffer.concat(chunks).toString())
+      }
+      const onError = err => {
+        teardown()
+        reject(err)
+      }
+      /**
+       * Detach all stdin listeners so repeated calls don't leak handlers.
+       */
+      function teardown () {
+        process.stdin.removeListener('data', onData)
+        process.stdin.removeListener('end', onEnd)
+        process.stdin.removeListener('error', onError)
+      }
+      process.stdin.on('data', onData)
+      process.stdin.on('end', onEnd)
+      process.stdin.on('error', onError)
     })
   }
 

--- a/src/commands/runtime/sandbox/exec.js
+++ b/src/commands/runtime/sandbox/exec.js
@@ -19,10 +19,12 @@ const {
   parseEgressFlags,
   splitArgvAtDoubleDash,
   buildCommandList,
-  shellQuote
+  shellQuote,
+  logPolicy,
+  logPreviewUrls
 } = require('../../../sandbox-helpers')
 
-const COMMAND_TIMEOUT_MS = 30000
+const DEFAULT_COMMAND_TIMEOUT_MS = 30000
 
 class SandboxExec extends RuntimeBaseCommand {
   async init () {
@@ -64,8 +66,8 @@ class SandboxExec extends RuntimeBaseCommand {
       })
       this.log(`Created: ${sandbox.id}`)
 
-      this._logPolicy(policy)
-      await this._logPreviewUrls(sandbox, ports)
+      logPolicy(policy, msg => this.log(msg))
+      await logPreviewUrls(sandbox, ports, msg => this.log(msg))
 
       await this._runCommands(sandbox, commands, flags)
     } catch (err) {
@@ -94,34 +96,6 @@ class SandboxExec extends RuntimeBaseCommand {
   _failUsage (message) {
     process.stderr.write(`${message}\n`)
     process.exitCode = 2
-  }
-
-  _logPolicy (policy) {
-    if (!policy) {
-      this.log('Network policy: default-deny (DNS + NATS only)')
-      return
-    }
-    if (policy.network.egress === 'allow-all') {
-      this.log('Network policy: allow-all egress')
-      return
-    }
-    this.log('Network policy: custom egress')
-    policy.network.egress.forEach(rule => {
-      const proto = rule.protocol || 'TCP'
-      const l7 = rule.rules ? ' ' + rule.rules.map(r => `${r.methods.join(',')}:${r.pathPattern}`).join(' ') : ''
-      this.log(`  - ${rule.host}:${rule.port} (${proto})${l7}`)
-    })
-  }
-
-  async _logPreviewUrls (sandbox, ports) {
-    if (!ports) {
-      return
-    }
-
-    this.log('Preview URLs:')
-    for (const port of ports) {
-      this.log(`  - ${port}: ${await sandbox.getUrl(port)}`)
-    }
   }
 
   async _runCommands (sandbox, commands, flags) {
@@ -188,7 +162,7 @@ SandboxExec.flags = {
   }),
   'command-timeout': Flags.integer({
     description: 'per-command timeout in milliseconds',
-    default: COMMAND_TIMEOUT_MS
+    default: DEFAULT_COMMAND_TIMEOUT_MS
   }),
   'fail-fast': Flags.boolean({
     description: 'stop execution when a command returns a non-zero exit code',

--- a/src/commands/runtime/sandbox/exec.js
+++ b/src/commands/runtime/sandbox/exec.js
@@ -30,7 +30,9 @@ class SandboxExec extends RuntimeBaseCommand {
     // (notably Windows PowerShell) the piped data and EOF arrive during the
     // parse, and attaching listeners afterwards would miss them.
     const stdinPromise = process.stdin.isTTY === true ? Promise.resolve('') : this._readStdin()
-    stdinPromise.catch(() => {}) // parse may reject first; avoid an unhandled rejection
+    // Avoid an unhandled rejection if parse rejects before we await this; a real
+    // stdin read error still surfaces at the `await stdinPromise` below.
+    stdinPromise.catch(() => {})
 
     const { args, flags } = await this.parse(SandboxExec)
 

--- a/src/commands/runtime/sandbox/exec.js
+++ b/src/commands/runtime/sandbox/exec.js
@@ -11,15 +11,13 @@ governing permissions and limitations under the License.
 */
 
 const { Sandbox } = require('@adobe/aio-lib-sandbox')
-const { Flags } = require('@oclif/core')
+const { Args, Flags } = require('@oclif/core')
 const RuntimeBaseCommand = require('../../../RuntimeBaseCommand')
 const {
   buildNetworkPolicy,
   parsePortFlags,
   parseEgressFlags,
-  splitArgvAtDoubleDash,
   buildCommandList,
-  shellQuote,
   logPolicy,
   logPreviewUrls
 } = require('../../../sandbox-helpers')
@@ -27,23 +25,14 @@ const {
 const DEFAULT_COMMAND_TIMEOUT_MS = 30000
 
 class SandboxExec extends RuntimeBaseCommand {
-  async init () {
-    const rawArgv = [...this.argv]
-    const { cliArgs } = splitArgvAtDoubleDash(rawArgv)
-
-    await this.parse(SandboxExec, cliArgs)
-    this.argv = rawArgv
-  }
-
   async run () {
-    const { cliArgs, commandArgs } = splitArgvAtDoubleDash(this.argv)
-    const { flags } = await this.parse(SandboxExec, cliArgs)
+    const { args, flags } = await this.parse(SandboxExec)
 
     const stdinText = process.stdin.isTTY === true ? '' : await this._readStdin()
-    const commands = buildCommandList(commandArgs, stdinText)
+    const commands = buildCommandList(args.command, stdinText)
 
     if (commands.length === 0) {
-      this._failUsage('No commands to run. Pass a command after "--" and/or pipe a newline-separated list on stdin. For an interactive session use "aio runtime sandbox run".')
+      this._failUsage('No commands to run. Pass a quoted command (e.g. \'node --version\') and/or pipe a newline-separated list on stdin. For an interactive session use "aio runtime sandbox run".')
       return
     }
 
@@ -125,8 +114,8 @@ access.
 
 Create a sandbox and run one or more commands non-interactively, then destroy it.
 
-Provide a one-shot command after "--" and/or pipe a newline-separated list of
-commands on stdin. When both are given, the one-shot command runs first,
+Provide a one-shot command as a quoted argument and/or pipe a newline-separated
+list of commands on stdin. When both are given, the one-shot command runs first,
 followed by the piped commands in order.
 
 Each command runs in a fresh process. Shell state (working directory, env
@@ -149,12 +138,16 @@ SandboxExec.flags = {
   egress: Flags.string({
     char: 'e',
     description: 'egress rule in host:port[:protocol][|METHOD:path] format, or "allow-all" (repeatable)',
-    multiple: true
+    multiple: true,
+    // non-greedy so a trailing positional command is not swallowed as an egress value
+    multipleNonGreedy: true
   }),
   port: Flags.string({
     char: 'p',
     description: 'Port to expose via a preview URL (repeatable)',
-    multiple: true
+    multiple: true,
+    // non-greedy so a trailing positional command is not swallowed as a port value
+    multipleNonGreedy: true
   }),
   'max-lifetime': Flags.integer({
     description: 'maximum sandbox lifetime in seconds',
@@ -170,10 +163,17 @@ SandboxExec.flags = {
   })
 }
 
+SandboxExec.args = {
+  command: Args.string({
+    description: 'command to run in the sandbox (quote multi-word commands)',
+    required: false
+  })
+}
+
 SandboxExec.examples = [
-  '<%= config.bin %> <%= command.id %> -- node --version',
+  '<%= config.bin %> <%= command.id %> "node --version"',
   '<%= config.bin %> <%= command.id %> < commands.txt',
-  '<%= config.bin %> <%= command.id %> -- node --version < commands.txt',
+  '<%= config.bin %> <%= command.id %> "node --version" < commands.txt',
   '<%= config.bin %> <%= command.id %> -e allow-all -p 5173 < commands.txt',
   '<%= config.bin %> <%= command.id %> --fail-fast --command-timeout 120000 < commands.txt'
 ]
@@ -184,8 +184,6 @@ SandboxExec.aliases = ['rt:sandbox:exec']
 SandboxExec.parseEgressFlags = parseEgressFlags
 SandboxExec.parsePortFlags = parsePortFlags
 SandboxExec.buildNetworkPolicy = buildNetworkPolicy
-SandboxExec.splitArgvAtDoubleDash = splitArgvAtDoubleDash
 SandboxExec.buildCommandList = buildCommandList
-SandboxExec.shellQuote = shellQuote
 
 module.exports = SandboxExec

--- a/src/commands/runtime/sandbox/run.js
+++ b/src/commands/runtime/sandbox/run.js
@@ -72,12 +72,12 @@ class SandboxRun extends RuntimeBaseCommand {
     const { flags } = await this.parse(SandboxRun, cliArgs)
 
     if (commandArgs.length > 0) {
-      this._failUsage('This command only supports interactive use. Omit "-- <command>" and type commands when prompted.')
+      this._failUsage('This command only supports interactive use. Omit "-- <command>" and type commands when prompted, or use "aio runtime sandbox exec" for one-shot or scripted commands.')
       return
     }
 
     if (process.stdin.isTTY !== true) {
-      this._failUsage('This command requires an interactive terminal. Piped stdin is not supported.')
+      this._failUsage('This command requires an interactive terminal. Piped stdin is not supported; use "aio runtime sandbox exec" to run a piped list of commands.')
       return
     }
 

--- a/src/commands/runtime/sandbox/run.js
+++ b/src/commands/runtime/sandbox/run.js
@@ -18,7 +18,9 @@ const {
   buildNetworkPolicy,
   parsePortFlags,
   parseEgressFlags,
-  splitArgvAtDoubleDash
+  splitArgvAtDoubleDash,
+  logPolicy,
+  logPreviewUrls
 } = require('../../../sandbox-helpers')
 
 const EXEC_TIMEOUT_MS = 30000
@@ -72,7 +74,7 @@ class SandboxRun extends RuntimeBaseCommand {
     const { flags } = await this.parse(SandboxRun, cliArgs)
 
     if (commandArgs.length > 0) {
-      this._failUsage('This command only supports interactive use. Omit "-- <command>" and type commands when prompted, or use "aio runtime sandbox exec" for one-shot or scripted commands.')
+      this._failUsage('This command only supports interactive use. Type commands when prompted, or use "aio runtime sandbox exec" for one-shot or scripted commands.')
       return
     }
 
@@ -101,8 +103,8 @@ class SandboxRun extends RuntimeBaseCommand {
       })
       this.log(`Created: ${sandbox.id}`)
 
-      this._logPolicy(policy)
-      await this._logPreviewUrls(sandbox, ports)
+      logPolicy(policy, msg => this.log(msg))
+      await logPreviewUrls(sandbox, ports, msg => this.log(msg))
 
       this.log('\nSandbox ready. Type "exit" to destroy and quit.\n')
 
@@ -129,34 +131,6 @@ class SandboxRun extends RuntimeBaseCommand {
   _failUsage (message) {
     process.stderr.write(`${message}\n`)
     process.exitCode = 2
-  }
-
-  _logPolicy (policy) {
-    if (!policy) {
-      this.log('Network policy: default-deny (DNS + NATS only)')
-      return
-    }
-    if (policy.network.egress === 'allow-all') {
-      this.log('Network policy: allow-all egress')
-      return
-    }
-    this.log('Network policy: custom egress')
-    policy.network.egress.forEach(rule => {
-      const proto = rule.protocol || 'TCP'
-      const l7 = rule.rules ? ' ' + rule.rules.map(r => `${r.methods.join(',')}:${r.pathPattern}`).join(' ') : ''
-      this.log(`  - ${rule.host}:${rule.port} (${proto})${l7}`)
-    })
-  }
-
-  async _logPreviewUrls (sandbox, ports) {
-    if (!ports) {
-      return
-    }
-
-    this.log('Preview URLs:')
-    for (const port of ports) {
-      this.log(`  - ${port}: ${await sandbox.getUrl(port)}`)
-    }
   }
 
   async _repl (rl, sandbox) {

--- a/src/sandbox-helpers.js
+++ b/src/sandbox-helpers.js
@@ -135,37 +135,19 @@ function buildNetworkPolicy (egressArgs) {
 }
 
 /**
- * Quote a single argv token so it survives re-parsing by the sandbox's shell.
- * Safe tokens are returned untouched; anything else is wrapped in single quotes
- * with embedded single quotes escaped, keeping spaces and shell metacharacters
- * literal.
- *
- * @param {string} arg argv token
- * @returns {string} shell-safe token
- */
-function shellQuote (arg) {
-  if (/^[A-Za-z0-9_./:=@%+,-]+$/.test(arg)) {
-    return arg
-  }
-  return `'${arg.replace(/'/g, "'\\''")}'`
-}
-
-/**
  * Build the ordered list of commands for a non-interactive `exec` run. The
- * one-shot command (everything after `--`) runs first, followed by each
- * newline-separated command read from piped stdin; blank lines are dropped.
- * One-shot tokens are shell-quoted before joining so arguments with spaces or
- * metacharacters survive the round-trip to the sandbox's shell, while piped
- * lines are already complete command strings and are passed through verbatim.
+ * one-shot command runs first, followed by each newline-separated command read
+ * from piped stdin; blank lines are dropped. Both are complete command strings
+ * (the one-shot is quoted by the user) and are passed through verbatim.
  *
- * @param {string[]} commandArgs argv tokens after `--`
+ * @param {string|undefined} command the one-shot command, or undefined
  * @param {string} stdinText raw piped stdin contents
  * @returns {string[]} ordered commands to execute
  */
-function buildCommandList (commandArgs, stdinText) {
+function buildCommandList (command, stdinText) {
   const commands = []
-  if (commandArgs && commandArgs.length > 0) {
-    commands.push(commandArgs.map(shellQuote).join(' '))
+  if (command) {
+    commands.push(command)
   }
   if (stdinText) {
     for (const line of stdinText.split('\n')) {
@@ -226,7 +208,6 @@ module.exports = {
   parseEgressFlags,
   splitArgvAtDoubleDash,
   buildCommandList,
-  shellQuote,
   logPolicy,
   logPreviewUrls
 }

--- a/src/sandbox-helpers.js
+++ b/src/sandbox-helpers.js
@@ -178,11 +178,55 @@ function buildCommandList (commandArgs, stdinText) {
   return commands
 }
 
+/**
+ * Log a human-readable summary of the sandbox network policy.
+ *
+ * @param {object|undefined} policy sandbox policy, or undefined for default-deny
+ * @param {Function} log logger called with each line
+ */
+function logPolicy (policy, log) {
+  if (!policy) {
+    log('Network policy: default-deny (DNS + NATS only)')
+    return
+  }
+  if (policy.network.egress === 'allow-all') {
+    log('Network policy: allow-all egress')
+    return
+  }
+  log('Network policy: custom egress')
+  policy.network.egress.forEach(rule => {
+    const proto = rule.protocol || 'TCP'
+    const l7 = rule.rules ? ' ' + rule.rules.map(r => `${r.methods.join(',')}:${r.pathPattern}`).join(' ') : ''
+    log(`  - ${rule.host}:${rule.port} (${proto})${l7}`)
+  })
+}
+
+/**
+ * Log the preview URL for each exposed port, or nothing when no ports.
+ *
+ * @param {object} sandbox sandbox instance exposing getUrl(port)
+ * @param {number[]|undefined} ports exposed ports
+ * @param {Function} log logger called with each line
+ * @returns {Promise<void>} resolves once all URLs are logged
+ */
+async function logPreviewUrls (sandbox, ports, log) {
+  if (!ports) {
+    return
+  }
+
+  log('Preview URLs:')
+  for (const port of ports) {
+    log(`  - ${port}: ${await sandbox.getUrl(port)}`)
+  }
+}
+
 module.exports = {
   buildNetworkPolicy,
   parsePortFlags,
   parseEgressFlags,
   splitArgvAtDoubleDash,
   buildCommandList,
-  shellQuote
+  shellQuote,
+  logPolicy,
+  logPreviewUrls
 }

--- a/src/sandbox-helpers.js
+++ b/src/sandbox-helpers.js
@@ -134,9 +134,55 @@ function buildNetworkPolicy (egressArgs) {
   return { network: { egress: parseEgressFlags(egressArgs) } }
 }
 
+/**
+ * Quote a single argv token so it survives re-parsing by the sandbox's shell.
+ * Safe tokens are returned untouched; anything else is wrapped in single quotes
+ * with embedded single quotes escaped, keeping spaces and shell metacharacters
+ * literal.
+ *
+ * @param {string} arg argv token
+ * @returns {string} shell-safe token
+ */
+function shellQuote (arg) {
+  if (/^[A-Za-z0-9_./:=@%+,-]+$/.test(arg)) {
+    return arg
+  }
+  return `'${arg.replace(/'/g, "'\\''")}'`
+}
+
+/**
+ * Build the ordered list of commands for a non-interactive `exec` run. The
+ * one-shot command (everything after `--`) runs first, followed by each
+ * newline-separated command read from piped stdin; blank lines are dropped.
+ * One-shot tokens are shell-quoted before joining so arguments with spaces or
+ * metacharacters survive the round-trip to the sandbox's shell, while piped
+ * lines are already complete command strings and are passed through verbatim.
+ *
+ * @param {string[]} commandArgs argv tokens after `--`
+ * @param {string} stdinText raw piped stdin contents
+ * @returns {string[]} ordered commands to execute
+ */
+function buildCommandList (commandArgs, stdinText) {
+  const commands = []
+  if (commandArgs && commandArgs.length > 0) {
+    commands.push(commandArgs.map(shellQuote).join(' '))
+  }
+  if (stdinText) {
+    for (const line of stdinText.split('\n')) {
+      const trimmed = line.trim()
+      if (trimmed) {
+        commands.push(trimmed)
+      }
+    }
+  }
+  return commands
+}
+
 module.exports = {
   buildNetworkPolicy,
   parsePortFlags,
   parseEgressFlags,
-  splitArgvAtDoubleDash
+  splitArgvAtDoubleDash,
+  buildCommandList,
+  shellQuote
 }

--- a/test/commands/runtime/sandbox/exec.test.js
+++ b/test/commands/runtime/sandbox/exec.test.js
@@ -91,6 +91,31 @@ describe('_readStdin', () => {
     process.stdin.removeAllListeners('end')
     process.stdin.removeAllListeners('error')
   })
+
+  test('removes its listeners after resolving (no leak)', async () => {
+    const command = new TheCommand([])
+    const before = {
+      data: process.stdin.listenerCount('data'),
+      end: process.stdin.listenerCount('end'),
+      error: process.stdin.listenerCount('error')
+    }
+    const promise = command._readStdin()
+    process.stdin.emit('data', Buffer.from('x\n'))
+    process.stdin.emit('end')
+    await promise
+    expect(process.stdin.listenerCount('data')).toBe(before.data)
+    expect(process.stdin.listenerCount('end')).toBe(before.end)
+    expect(process.stdin.listenerCount('error')).toBe(before.error)
+  })
+
+  test('removes its listeners after rejecting (no leak)', async () => {
+    const command = new TheCommand([])
+    const before = process.stdin.listenerCount('error')
+    const promise = command._readStdin()
+    process.stdin.emit('error', new Error('boom'))
+    await expect(promise).rejects.toThrow('boom')
+    expect(process.stdin.listenerCount('error')).toBe(before)
+  })
 })
 
 describe('buildCommandList', () => {

--- a/test/commands/runtime/sandbox/exec.test.js
+++ b/test/commands/runtime/sandbox/exec.test.js
@@ -1,0 +1,355 @@
+/*
+Copyright 2026 Adobe Inc. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { stdout, stderr } = require('stdout-stderr')
+beforeEach(() => { stdout.start(); stderr.start() })
+afterEach(() => { stdout.stop(); stderr.stop() })
+const TheCommand = require('../../../../src/commands/runtime/sandbox/exec.js')
+const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand.js')
+const { Sandbox } = require('@adobe/aio-lib-sandbox')
+
+/**
+ * Build a fake `Sandbox` object suitable for stubbing Sandbox.create resolutions.
+ *
+ * @param {object} [overrides] override individual fields
+ * @returns {object} fake sandbox
+ */
+function fakeSandbox (overrides = {}) {
+  return {
+    id: 'sandbox-123',
+    exec: jest.fn().mockResolvedValue({ stdout: 'ok\n', stderr: '', exitCode: 0 }),
+    getUrl: jest.fn(port => Promise.resolve(`https://sandbox-${port}.example.net`)),
+    destroy: jest.fn().mockResolvedValue({ status: 'destroyed' }),
+    ...overrides
+  }
+}
+
+test('exports', async () => {
+  expect(typeof TheCommand).toEqual('function')
+  expect(TheCommand.prototype instanceof RuntimeBaseCommand).toBeTruthy()
+})
+
+test('description', async () => {
+  expect(TheCommand.description).toBeDefined()
+  expect(TheCommand.description).toMatch(/sandbox run/)
+})
+
+test('aliases', async () => {
+  expect(TheCommand.aliases).toContain('rt:sandbox:exec')
+})
+
+test('examples', async () => {
+  expect(TheCommand.examples).toBeInstanceOf(Array)
+  expect(TheCommand.examples.length).toBeGreaterThan(0)
+})
+
+test('flags', async () => {
+  // shared with run
+  expect(TheCommand.flags.name.char).toBe('n')
+  expect(TheCommand.flags.name.default).toBe('aio-sandbox')
+  expect(TheCommand.flags.egress.char).toBe('e')
+  expect(TheCommand.flags.egress.multiple).toBe(true)
+  expect(TheCommand.flags.port.char).toBe('p')
+  expect(TheCommand.flags.port.multiple).toBe(true)
+  expect(TheCommand.flags['max-lifetime'].default).toBe(3600)
+  // exec-specific: --command-timeout is the per-command cap, default 30s
+  expect(TheCommand.flags['command-timeout'].default).toBe(30000)
+  expect(TheCommand.flags['fail-fast']).toBeDefined()
+  // inherits base flags
+  expect(TheCommand.flags.apihost).toBeDefined()
+})
+
+describe('init', () => {
+  test('ignores sandbox command args after -- during oclif parsing', async () => {
+    const command = new TheCommand(['--', 'node', '--version'])
+
+    await expect(command.init()).resolves.toBeUndefined()
+    expect(command.argv).toEqual(['--', 'node', '--version'])
+  })
+})
+
+describe('_readStdin', () => {
+  test('collects piped chunks until end', async () => {
+    const command = new TheCommand([])
+    const promise = command._readStdin()
+    process.stdin.emit('data', Buffer.from('echo one\n'))
+    process.stdin.emit('data', Buffer.from('echo two\n'))
+    process.stdin.emit('end')
+    await expect(promise).resolves.toBe('echo one\necho two\n')
+    process.stdin.removeAllListeners('data')
+    process.stdin.removeAllListeners('end')
+    process.stdin.removeAllListeners('error')
+  })
+
+  test('rejects on stdin error', async () => {
+    const command = new TheCommand([])
+    const promise = command._readStdin()
+    process.stdin.emit('error', new Error('stdin boom'))
+    await expect(promise).rejects.toThrow('stdin boom')
+    process.stdin.removeAllListeners('data')
+    process.stdin.removeAllListeners('end')
+    process.stdin.removeAllListeners('error')
+  })
+})
+
+describe('shellQuote', () => {
+  test('leaves safe tokens untouched', () => {
+    expect(TheCommand.shellQuote('node')).toBe('node')
+    expect(TheCommand.shellQuote('--version')).toBe('--version')
+    expect(TheCommand.shellQuote('vite@latest')).toBe('vite@latest')
+    expect(TheCommand.shellQuote('a/b.c_d:e=f')).toBe('a/b.c_d:e=f')
+  })
+
+  test('single-quotes tokens with spaces', () => {
+    expect(TheCommand.shellQuote('a b')).toBe("'a b'")
+  })
+
+  test('single-quotes shell metacharacters so they stay literal', () => {
+    expect(TheCommand.shellQuote('*')).toBe("'*'")
+    expect(TheCommand.shellQuote('a && b')).toBe("'a && b'")
+  })
+
+  test('escapes embedded single quotes', () => {
+    expect(TheCommand.shellQuote("can't")).toBe("'can'\\''t'")
+  })
+})
+
+describe('buildCommandList', () => {
+  test('one-shot only', () => {
+    expect(TheCommand.buildCommandList(['node', '--version'], '')).toEqual(['node --version'])
+  })
+
+  test('shell-quotes one-shot tokens that need it', () => {
+    expect(TheCommand.buildCommandList(['echo', 'a b'], '')).toEqual(["echo 'a b'"])
+    expect(TheCommand.buildCommandList(['echo', '*'], '')).toEqual(["echo '*'"])
+  })
+
+  test('piped only, newline-split, blanks dropped', () => {
+    expect(TheCommand.buildCommandList([], 'a\n\nb\n')).toEqual(['a', 'b'])
+  })
+
+  test('piped lines are passed verbatim, not quoted', () => {
+    expect(TheCommand.buildCommandList([], 'cd app && npm install\n')).toEqual(['cd app && npm install'])
+  })
+
+  test('one-shot runs first, then piped', () => {
+    expect(TheCommand.buildCommandList(['node', '--version'], 'a\nb')).toEqual(['node --version', 'a', 'b'])
+  })
+
+  test('empty when nothing provided', () => {
+    expect(TheCommand.buildCommandList([], '')).toEqual([])
+  })
+})
+
+describe('run', () => {
+  let command
+  let handleError
+  let sandbox
+  const originalStdinIsTTY = process.stdin.isTTY
+  const originalExitCode = process.exitCode
+
+  beforeEach(async () => {
+    command = new TheCommand([])
+    handleError = jest.spyOn(command, 'handleError').mockResolvedValue(undefined)
+    sandbox = fakeSandbox()
+    Sandbox.create.mockReset()
+    Sandbox.create.mockResolvedValue(sandbox)
+    jest.spyOn(command, '_readStdin').mockResolvedValue('')
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
+  })
+
+  afterEach(() => {
+    process.exitCode = originalExitCode
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true })
+  })
+
+  test('runs a single one-shot command and destroys', async () => {
+    command.argv = ['--', 'node', '--version']
+    command._readStdin.mockResolvedValue('')
+    sandbox.exec.mockResolvedValueOnce({ stdout: 'v25.9.0\n', stderr: '', exitCode: 0 })
+
+    await command.run()
+
+    expect(sandbox.exec).toHaveBeenCalledWith('node --version', { timeout: 30000 })
+    expect(stdout.output).toMatch('v25.9.0')
+    expect(stdout.output).toMatch('[exit: 0]')
+    expect(sandbox.destroy).toHaveBeenCalled()
+  })
+
+  test('runs piped commands in order', async () => {
+    command.argv = []
+    command._readStdin.mockResolvedValue('echo one\necho two\n')
+
+    await command.run()
+
+    expect(sandbox.exec).toHaveBeenNthCalledWith(1, 'echo one', { timeout: 30000 })
+    expect(sandbox.exec).toHaveBeenNthCalledWith(2, 'echo two', { timeout: 30000 })
+  })
+
+  test('one-shot runs before piped commands', async () => {
+    command.argv = ['--', 'node', '--version']
+    command._readStdin.mockResolvedValue('echo after\n')
+
+    await command.run()
+
+    expect(sandbox.exec).toHaveBeenNthCalledWith(1, 'node --version', { timeout: 30000 })
+    expect(sandbox.exec).toHaveBeenNthCalledWith(2, 'echo after', { timeout: 30000 })
+  })
+
+  test('does not read stdin on a TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    command.argv = ['--', 'true']
+
+    await command.run()
+
+    expect(command._readStdin).not.toHaveBeenCalled()
+    expect(sandbox.exec).toHaveBeenCalledWith('true', { timeout: 30000 })
+  })
+
+  test('defaults the per-command timeout to 30s when --command-timeout is omitted', async () => {
+    command.argv = ['--', 'true']
+
+    await command.run()
+
+    expect(sandbox.exec).toHaveBeenCalledWith('true', { timeout: 30000 })
+  })
+
+  test('--command-timeout overrides the per-command default', async () => {
+    command.argv = ['--command-timeout', '5000', '--', 'true']
+
+    await command.run()
+
+    expect(sandbox.exec).toHaveBeenCalledWith('true', { timeout: 5000 })
+  })
+
+  test('--fail-fast stops on first non-zero exit and sets exit code', async () => {
+    command.argv = ['--fail-fast']
+    command._readStdin.mockResolvedValue('bad\ngood\n')
+    sandbox.exec.mockResolvedValueOnce({ stdout: '', stderr: 'nope\n', exitCode: 1 })
+
+    await command.run()
+
+    expect(sandbox.exec).toHaveBeenCalledTimes(1)
+    expect(sandbox.exec).toHaveBeenCalledWith('bad', { timeout: 30000 })
+    expect(process.exitCode).toBe(1)
+    expect(sandbox.destroy).toHaveBeenCalled()
+  })
+
+  test('without --fail-fast runs all and exits with last non-zero code', async () => {
+    command.argv = []
+    command._readStdin.mockResolvedValue('first\nsecond\nthird\n')
+    sandbox.exec
+      .mockResolvedValueOnce({ stdout: '', stderr: 'e1\n', exitCode: 3 })
+      .mockResolvedValueOnce({ stdout: 'ok\n', stderr: '', exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: '', stderr: 'e2\n', exitCode: 5 })
+
+    await command.run()
+
+    expect(sandbox.exec).toHaveBeenCalledTimes(3)
+    expect(process.exitCode).toBe(5)
+  })
+
+  test('exits 0 when all commands succeed', async () => {
+    command.argv = []
+    command._readStdin.mockResolvedValue('a\nb\n')
+    process.exitCode = 0
+
+    await command.run()
+
+    expect(sandbox.exec).toHaveBeenCalledTimes(2)
+    expect(process.exitCode).toBe(0)
+  })
+
+  test('errors when no command is provided on a TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    command.argv = []
+    command._readStdin.mockResolvedValue('')
+
+    await command.run()
+
+    expect(stderr.output).toMatch(/no commands/i)
+    expect(stderr.output).toMatch(/sandbox run/)
+    expect(process.exitCode).toBe(2)
+    expect(Sandbox.create).not.toHaveBeenCalled()
+    expect(sandbox.destroy).not.toHaveBeenCalled()
+  })
+
+  test('forwards name, egress, port, max-lifetime to Sandbox.create', async () => {
+    command.argv = ['-n', 'mybox', '--max-lifetime', '600', '-e', 'allow-all', '-p', '5173', '--', 'true']
+
+    await command.run()
+
+    expect(Sandbox.create).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'mybox',
+      maxLifetime: 600,
+      ports: [5173],
+      policy: { network: { egress: 'allow-all' } }
+    }))
+    expect(sandbox.getUrl).toHaveBeenCalledWith(5173)
+  })
+
+  test('logs custom egress rules', async () => {
+    command.argv = ['-e', 'pypi.org:443', '-e', 'api.github.com:443|GET:/repos/**', '--', 'true']
+
+    await command.run()
+
+    expect(stdout.output).toMatch('Network policy: custom egress')
+    expect(stdout.output).toMatch('pypi.org:443 (TCP)')
+    expect(stdout.output).toMatch('api.github.com:443 (TCP) GET:/repos/**')
+  })
+
+  test('logs default-deny policy when no egress', async () => {
+    command.argv = ['--', 'true']
+
+    await command.run()
+
+    expect(stdout.output).toMatch('Network policy: default-deny')
+  })
+
+  test('reports command stderr', async () => {
+    command.argv = ['--', 'cat', 'missing']
+    sandbox.exec.mockResolvedValueOnce({ stdout: '', stderr: 'no such file\n', exitCode: 1 })
+
+    await command.run()
+
+    expect(stderr.output).toMatch('no such file')
+    expect(stdout.output).toMatch('[exit: 1]')
+  })
+
+  test('routes create errors through handleError and skips destroy', async () => {
+    Sandbox.create.mockRejectedValue(new Error('boom'))
+    command.argv = ['--', 'true']
+
+    await command.run()
+
+    expect(handleError).toHaveBeenCalledWith('failed to exec in sandbox', expect.objectContaining({ message: 'boom' }))
+    expect(sandbox.destroy).not.toHaveBeenCalled()
+  })
+
+  test('logs a message when destroy fails', async () => {
+    sandbox.destroy.mockRejectedValue(new Error('destroy failed'))
+    command.argv = ['--', 'true']
+
+    await command.run()
+
+    expect(stdout.output).toMatch('failed to destroy sandbox: destroy failed')
+  })
+
+  test('logs a stringified value when destroy rejects without .message', async () => {
+    sandbox.destroy.mockRejectedValue('plain reason')
+    command.argv = ['--', 'true']
+
+    await command.run()
+
+    expect(stdout.output).toMatch('failed to destroy sandbox: plain reason')
+  })
+})

--- a/test/commands/runtime/sandbox/exec.test.js
+++ b/test/commands/runtime/sandbox/exec.test.js
@@ -17,6 +17,9 @@ const TheCommand = require('../../../../src/commands/runtime/sandbox/exec.js')
 const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand.js')
 const { Sandbox } = require('@adobe/aio-lib-sandbox')
 const { logPolicy, logPreviewUrls } = require('../../../../src/sandbox-helpers')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 
 /**
  * Build a fake `Sandbox` object suitable for stubbing Sandbox.create resolutions.
@@ -65,56 +68,21 @@ test('flags', async () => {
   // exec-specific: --command-timeout is the per-command cap, default 30s
   expect(TheCommand.flags['command-timeout'].default).toBe(30000)
   expect(TheCommand.flags['fail-fast']).toBeDefined()
+  expect(TheCommand.flags.file.char).toBe('f')
   // inherits base flags
   expect(TheCommand.flags.apihost).toBeDefined()
 })
 
-describe('_readStdin', () => {
-  test('collects piped chunks until end', async () => {
+describe('_readFile', () => {
+  test('reads file contents as utf8', () => {
     const command = new TheCommand([])
-    const promise = command._readStdin()
-    process.stdin.emit('data', Buffer.from('echo one\n'))
-    process.stdin.emit('data', Buffer.from('echo two\n'))
-    process.stdin.emit('end')
-    await expect(promise).resolves.toBe('echo one\necho two\n')
-    process.stdin.removeAllListeners('data')
-    process.stdin.removeAllListeners('end')
-    process.stdin.removeAllListeners('error')
-  })
-
-  test('rejects on stdin error', async () => {
-    const command = new TheCommand([])
-    const promise = command._readStdin()
-    process.stdin.emit('error', new Error('stdin boom'))
-    await expect(promise).rejects.toThrow('stdin boom')
-    process.stdin.removeAllListeners('data')
-    process.stdin.removeAllListeners('end')
-    process.stdin.removeAllListeners('error')
-  })
-
-  test('removes its listeners after resolving (no leak)', async () => {
-    const command = new TheCommand([])
-    const before = {
-      data: process.stdin.listenerCount('data'),
-      end: process.stdin.listenerCount('end'),
-      error: process.stdin.listenerCount('error')
+    const tmp = path.join(os.tmpdir(), `exec-readfile-${Date.now()}.txt`)
+    fs.writeFileSync(tmp, 'echo hi\n')
+    try {
+      expect(command._readFile(tmp)).toBe('echo hi\n')
+    } finally {
+      fs.unlinkSync(tmp)
     }
-    const promise = command._readStdin()
-    process.stdin.emit('data', Buffer.from('x\n'))
-    process.stdin.emit('end')
-    await promise
-    expect(process.stdin.listenerCount('data')).toBe(before.data)
-    expect(process.stdin.listenerCount('end')).toBe(before.end)
-    expect(process.stdin.listenerCount('error')).toBe(before.error)
-  })
-
-  test('removes its listeners after rejecting (no leak)', async () => {
-    const command = new TheCommand([])
-    const before = process.stdin.listenerCount('error')
-    const promise = command._readStdin()
-    process.stdin.emit('error', new Error('boom'))
-    await expect(promise).rejects.toThrow('boom')
-    expect(process.stdin.listenerCount('error')).toBe(before)
   })
 })
 
@@ -196,7 +164,6 @@ describe('run', () => {
   let command
   let handleError
   let sandbox
-  const originalStdinIsTTY = process.stdin.isTTY
   const originalExitCode = process.exitCode
 
   beforeEach(async () => {
@@ -205,18 +172,14 @@ describe('run', () => {
     sandbox = fakeSandbox()
     Sandbox.create.mockReset()
     Sandbox.create.mockResolvedValue(sandbox)
-    jest.spyOn(command, '_readStdin').mockResolvedValue('')
-    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true })
   })
 
   afterEach(() => {
     process.exitCode = originalExitCode
-    Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true })
   })
 
   test('runs a single one-shot command and destroys', async () => {
     command.argv = ['node --version']
-    command._readStdin.mockResolvedValue('')
     sandbox.exec.mockResolvedValueOnce({ stdout: 'v25.9.0\n', stderr: '', exitCode: 0 })
 
     await command.run()
@@ -225,36 +188,6 @@ describe('run', () => {
     expect(stdout.output).toMatch('v25.9.0')
     expect(stdout.output).toMatch('[exit: 0]')
     expect(sandbox.destroy).toHaveBeenCalled()
-  })
-
-  test('runs piped commands in order', async () => {
-    command.argv = []
-    command._readStdin.mockResolvedValue('echo one\necho two\n')
-
-    await command.run()
-
-    expect(sandbox.exec).toHaveBeenNthCalledWith(1, 'echo one', { timeout: 30000 })
-    expect(sandbox.exec).toHaveBeenNthCalledWith(2, 'echo two', { timeout: 30000 })
-  })
-
-  test('one-shot runs before piped commands', async () => {
-    command.argv = ['node --version']
-    command._readStdin.mockResolvedValue('echo after\n')
-
-    await command.run()
-
-    expect(sandbox.exec).toHaveBeenNthCalledWith(1, 'node --version', { timeout: 30000 })
-    expect(sandbox.exec).toHaveBeenNthCalledWith(2, 'echo after', { timeout: 30000 })
-  })
-
-  test('does not read stdin on a TTY', async () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
-    command.argv = ['true']
-
-    await command.run()
-
-    expect(command._readStdin).not.toHaveBeenCalled()
-    expect(sandbox.exec).toHaveBeenCalledWith('true', { timeout: 30000 })
   })
 
   test('defaults the per-command timeout to 30s when --command-timeout is omitted', async () => {
@@ -273,9 +206,62 @@ describe('run', () => {
     expect(sandbox.exec).toHaveBeenCalledWith('true', { timeout: 5000 })
   })
 
+  test('--file reads a newline-separated command list', async () => {
+    jest.spyOn(command, '_readFile').mockReturnValue('echo a\necho b\n')
+    command.argv = ['--file', 'cmds.txt']
+
+    await command.run()
+
+    expect(command._readFile).toHaveBeenCalledWith('cmds.txt')
+    expect(sandbox.exec).toHaveBeenNthCalledWith(1, 'echo a', { timeout: 30000 })
+    expect(sandbox.exec).toHaveBeenNthCalledWith(2, 'echo b', { timeout: 30000 })
+  })
+
+  test('--file with a one-shot command runs the one-shot first', async () => {
+    jest.spyOn(command, '_readFile').mockReturnValue('echo from-file\n')
+    command.argv = ['--file', 'cmds.txt', 'echo from-arg']
+
+    await command.run()
+
+    expect(sandbox.exec).toHaveBeenNthCalledWith(1, 'echo from-arg', { timeout: 30000 })
+    expect(sandbox.exec).toHaveBeenNthCalledWith(2, 'echo from-file', { timeout: 30000 })
+  })
+
+  test('-f is the short flag for --file', async () => {
+    jest.spyOn(command, '_readFile').mockReturnValue('echo from-file\n')
+    command.argv = ['-f', 'cmds.txt']
+
+    await command.run()
+
+    expect(command._readFile).toHaveBeenCalledWith('cmds.txt')
+    expect(sandbox.exec).toHaveBeenCalledTimes(1)
+    expect(sandbox.exec).toHaveBeenCalledWith('echo from-file', { timeout: 30000 })
+  })
+
+  test('--file with an unreadable path errors before creating a sandbox', async () => {
+    jest.spyOn(command, '_readFile').mockImplementation(() => { throw new Error('ENOENT: no such file') })
+    command.argv = ['--file', 'missing.txt']
+
+    await command.run()
+
+    expect(stderr.output).toMatch(/Cannot read --file/)
+    expect(process.exitCode).toBe(2)
+    expect(Sandbox.create).not.toHaveBeenCalled()
+  })
+
+  test('--file read error without .message stringifies the thrown value', async () => {
+    jest.spyOn(command, '_readFile').mockImplementation(() => { throw 'plain failure' }) // eslint-disable-line no-throw-literal
+    command.argv = ['--file', 'missing.txt']
+
+    await command.run()
+
+    expect(stderr.output).toMatch(/Cannot read --file "missing.txt": plain failure/)
+    expect(process.exitCode).toBe(2)
+  })
+
   test('--fail-fast stops on first non-zero exit and sets exit code', async () => {
-    command.argv = ['--fail-fast']
-    command._readStdin.mockResolvedValue('bad\ngood\n')
+    jest.spyOn(command, '_readFile').mockReturnValue('bad\ngood\n')
+    command.argv = ['--fail-fast', '--file', 'cmds.txt']
     sandbox.exec.mockResolvedValueOnce({ stdout: '', stderr: 'nope\n', exitCode: 1 })
 
     await command.run()
@@ -287,8 +273,8 @@ describe('run', () => {
   })
 
   test('without --fail-fast runs all and exits with last non-zero code', async () => {
-    command.argv = []
-    command._readStdin.mockResolvedValue('first\nsecond\nthird\n')
+    jest.spyOn(command, '_readFile').mockReturnValue('first\nsecond\nthird\n')
+    command.argv = ['--file', 'cmds.txt']
     sandbox.exec
       .mockResolvedValueOnce({ stdout: '', stderr: 'e1\n', exitCode: 3 })
       .mockResolvedValueOnce({ stdout: 'ok\n', stderr: '', exitCode: 0 })
@@ -301,8 +287,8 @@ describe('run', () => {
   })
 
   test('exits 0 when all commands succeed', async () => {
-    command.argv = []
-    command._readStdin.mockResolvedValue('a\nb\n')
+    jest.spyOn(command, '_readFile').mockReturnValue('a\nb\n')
+    command.argv = ['--file', 'cmds.txt']
     process.exitCode = 0
 
     await command.run()
@@ -311,10 +297,8 @@ describe('run', () => {
     expect(process.exitCode).toBe(0)
   })
 
-  test('errors when no command is provided on a TTY', async () => {
-    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+  test('errors when no command and no --file is provided', async () => {
     command.argv = []
-    command._readStdin.mockResolvedValue('')
 
     await command.run()
 

--- a/test/commands/runtime/sandbox/exec.test.js
+++ b/test/commands/runtime/sandbox/exec.test.js
@@ -16,6 +16,7 @@ afterEach(() => { stdout.stop(); stderr.stop() })
 const TheCommand = require('../../../../src/commands/runtime/sandbox/exec.js')
 const RuntimeBaseCommand = require('../../../../src/RuntimeBaseCommand.js')
 const { Sandbox } = require('@adobe/aio-lib-sandbox')
+const { logPolicy, logPreviewUrls } = require('../../../../src/sandbox-helpers')
 
 /**
  * Build a fake `Sandbox` object suitable for stubbing Sandbox.create resolutions.
@@ -147,6 +148,54 @@ describe('buildCommandList', () => {
 
   test('empty when nothing provided', () => {
     expect(TheCommand.buildCommandList([], '')).toEqual([])
+  })
+})
+
+describe('logPolicy', () => {
+  test('logs default-deny when no policy', () => {
+    const log = jest.fn()
+    logPolicy(undefined, log)
+    expect(log).toHaveBeenCalledWith('Network policy: default-deny (DNS + NATS only)')
+  })
+
+  test('logs allow-all egress', () => {
+    const log = jest.fn()
+    logPolicy({ network: { egress: 'allow-all' } }, log)
+    expect(log).toHaveBeenCalledWith('Network policy: allow-all egress')
+  })
+
+  test('logs custom egress rules', () => {
+    const log = jest.fn()
+    logPolicy({
+      network: {
+        egress: [
+          { host: 'pypi.org', port: 443 },
+          { host: 'api.github.com', port: 443, rules: [{ methods: ['GET'], pathPattern: '/repos/**' }] }
+        ]
+      }
+    }, log)
+    expect(log).toHaveBeenCalledWith('Network policy: custom egress')
+    expect(log).toHaveBeenCalledWith('  - pypi.org:443 (TCP)')
+    expect(log).toHaveBeenCalledWith('  - api.github.com:443 (TCP) GET:/repos/**')
+  })
+})
+
+describe('logPreviewUrls', () => {
+  test('does nothing when no ports', async () => {
+    const log = jest.fn()
+    const sandbox = { getUrl: jest.fn() }
+    await logPreviewUrls(sandbox, undefined, log)
+    expect(log).not.toHaveBeenCalled()
+    expect(sandbox.getUrl).not.toHaveBeenCalled()
+  })
+
+  test('logs a preview URL per port', async () => {
+    const log = jest.fn()
+    const sandbox = { getUrl: jest.fn(port => Promise.resolve(`https://sandbox-${port}.example.net`)) }
+    await logPreviewUrls(sandbox, [3000, 8080], log)
+    expect(log).toHaveBeenCalledWith('Preview URLs:')
+    expect(log).toHaveBeenCalledWith('  - 3000: https://sandbox-3000.example.net')
+    expect(log).toHaveBeenCalledWith('  - 8080: https://sandbox-8080.example.net')
   })
 })
 

--- a/test/commands/runtime/sandbox/exec.test.js
+++ b/test/commands/runtime/sandbox/exec.test.js
@@ -69,15 +69,6 @@ test('flags', async () => {
   expect(TheCommand.flags.apihost).toBeDefined()
 })
 
-describe('init', () => {
-  test('ignores sandbox command args after -- during oclif parsing', async () => {
-    const command = new TheCommand(['--', 'node', '--version'])
-
-    await expect(command.init()).resolves.toBeUndefined()
-    expect(command.argv).toEqual(['--', 'node', '--version'])
-  })
-})
-
 describe('_readStdin', () => {
   test('collects piped chunks until end', async () => {
     const command = new TheCommand([])
@@ -102,52 +93,29 @@ describe('_readStdin', () => {
   })
 })
 
-describe('shellQuote', () => {
-  test('leaves safe tokens untouched', () => {
-    expect(TheCommand.shellQuote('node')).toBe('node')
-    expect(TheCommand.shellQuote('--version')).toBe('--version')
-    expect(TheCommand.shellQuote('vite@latest')).toBe('vite@latest')
-    expect(TheCommand.shellQuote('a/b.c_d:e=f')).toBe('a/b.c_d:e=f')
-  })
-
-  test('single-quotes tokens with spaces', () => {
-    expect(TheCommand.shellQuote('a b')).toBe("'a b'")
-  })
-
-  test('single-quotes shell metacharacters so they stay literal', () => {
-    expect(TheCommand.shellQuote('*')).toBe("'*'")
-    expect(TheCommand.shellQuote('a && b')).toBe("'a && b'")
-  })
-
-  test('escapes embedded single quotes', () => {
-    expect(TheCommand.shellQuote("can't")).toBe("'can'\\''t'")
-  })
-})
-
 describe('buildCommandList', () => {
   test('one-shot only', () => {
-    expect(TheCommand.buildCommandList(['node', '--version'], '')).toEqual(['node --version'])
+    expect(TheCommand.buildCommandList('node --version', '')).toEqual(['node --version'])
   })
 
-  test('shell-quotes one-shot tokens that need it', () => {
-    expect(TheCommand.buildCommandList(['echo', 'a b'], '')).toEqual(["echo 'a b'"])
-    expect(TheCommand.buildCommandList(['echo', '*'], '')).toEqual(["echo '*'"])
+  test('one-shot command is passed verbatim', () => {
+    expect(TheCommand.buildCommandList('echo "a b"', '')).toEqual(['echo "a b"'])
   })
 
   test('piped only, newline-split, blanks dropped', () => {
-    expect(TheCommand.buildCommandList([], 'a\n\nb\n')).toEqual(['a', 'b'])
+    expect(TheCommand.buildCommandList(undefined, 'a\n\nb\n')).toEqual(['a', 'b'])
   })
 
-  test('piped lines are passed verbatim, not quoted', () => {
-    expect(TheCommand.buildCommandList([], 'cd app && npm install\n')).toEqual(['cd app && npm install'])
+  test('piped lines are passed verbatim', () => {
+    expect(TheCommand.buildCommandList(undefined, 'cd app && npm install\n')).toEqual(['cd app && npm install'])
   })
 
   test('one-shot runs first, then piped', () => {
-    expect(TheCommand.buildCommandList(['node', '--version'], 'a\nb')).toEqual(['node --version', 'a', 'b'])
+    expect(TheCommand.buildCommandList('node --version', 'a\nb')).toEqual(['node --version', 'a', 'b'])
   })
 
   test('empty when nothing provided', () => {
-    expect(TheCommand.buildCommandList([], '')).toEqual([])
+    expect(TheCommand.buildCommandList(undefined, '')).toEqual([])
   })
 })
 
@@ -222,7 +190,7 @@ describe('run', () => {
   })
 
   test('runs a single one-shot command and destroys', async () => {
-    command.argv = ['--', 'node', '--version']
+    command.argv = ['node --version']
     command._readStdin.mockResolvedValue('')
     sandbox.exec.mockResolvedValueOnce({ stdout: 'v25.9.0\n', stderr: '', exitCode: 0 })
 
@@ -245,7 +213,7 @@ describe('run', () => {
   })
 
   test('one-shot runs before piped commands', async () => {
-    command.argv = ['--', 'node', '--version']
+    command.argv = ['node --version']
     command._readStdin.mockResolvedValue('echo after\n')
 
     await command.run()
@@ -256,7 +224,7 @@ describe('run', () => {
 
   test('does not read stdin on a TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
-    command.argv = ['--', 'true']
+    command.argv = ['true']
 
     await command.run()
 
@@ -265,7 +233,7 @@ describe('run', () => {
   })
 
   test('defaults the per-command timeout to 30s when --command-timeout is omitted', async () => {
-    command.argv = ['--', 'true']
+    command.argv = ['true']
 
     await command.run()
 
@@ -273,7 +241,7 @@ describe('run', () => {
   })
 
   test('--command-timeout overrides the per-command default', async () => {
-    command.argv = ['--command-timeout', '5000', '--', 'true']
+    command.argv = ['--command-timeout', '5000', 'true']
 
     await command.run()
 
@@ -333,7 +301,7 @@ describe('run', () => {
   })
 
   test('forwards name, egress, port, max-lifetime to Sandbox.create', async () => {
-    command.argv = ['-n', 'mybox', '--max-lifetime', '600', '-e', 'allow-all', '-p', '5173', '--', 'true']
+    command.argv = ['-n', 'mybox', '--max-lifetime', '600', '-e', 'allow-all', '-p', '5173', 'true']
 
     await command.run()
 
@@ -347,7 +315,7 @@ describe('run', () => {
   })
 
   test('logs custom egress rules', async () => {
-    command.argv = ['-e', 'pypi.org:443', '-e', 'api.github.com:443|GET:/repos/**', '--', 'true']
+    command.argv = ['-e', 'pypi.org:443', '-e', 'api.github.com:443|GET:/repos/**', 'true']
 
     await command.run()
 
@@ -357,7 +325,7 @@ describe('run', () => {
   })
 
   test('logs default-deny policy when no egress', async () => {
-    command.argv = ['--', 'true']
+    command.argv = ['true']
 
     await command.run()
 
@@ -365,7 +333,7 @@ describe('run', () => {
   })
 
   test('reports command stderr', async () => {
-    command.argv = ['--', 'cat', 'missing']
+    command.argv = ['cat missing']
     sandbox.exec.mockResolvedValueOnce({ stdout: '', stderr: 'no such file\n', exitCode: 1 })
 
     await command.run()
@@ -376,7 +344,7 @@ describe('run', () => {
 
   test('routes create errors through handleError and skips destroy', async () => {
     Sandbox.create.mockRejectedValue(new Error('boom'))
-    command.argv = ['--', 'true']
+    command.argv = ['true']
 
     await command.run()
 
@@ -386,7 +354,7 @@ describe('run', () => {
 
   test('logs a message when destroy fails', async () => {
     sandbox.destroy.mockRejectedValue(new Error('destroy failed'))
-    command.argv = ['--', 'true']
+    command.argv = ['true']
 
     await command.run()
 
@@ -395,7 +363,7 @@ describe('run', () => {
 
   test('logs a stringified value when destroy rejects without .message', async () => {
     sandbox.destroy.mockRejectedValue('plain reason')
-    command.argv = ['--', 'true']
+    command.argv = ['true']
 
     await command.run()
 

--- a/test/commands/runtime/sandbox/exec.test.js
+++ b/test/commands/runtime/sandbox/exec.test.js
@@ -41,7 +41,7 @@ test('exports', async () => {
 
 test('description', async () => {
   expect(TheCommand.description).toBeDefined()
-  expect(TheCommand.description).toMatch(/sandbox run/)
+  expect(TheCommand.description).toMatch(/non-interactively/)
 })
 
 test('aliases', async () => {

--- a/test/commands/runtime/sandbox/run.test.js
+++ b/test/commands/runtime/sandbox/run.test.js
@@ -304,6 +304,7 @@ describe('run', () => {
     await command.run()
 
     expect(stderr.output).toMatch('only supports interactive use')
+    expect(stderr.output).toMatch('aio runtime sandbox exec')
     expect(stderr.output).not.toMatch('CLIError')
     expect(process.exitCode).toBe(2)
     expect(handleError).not.toHaveBeenCalled()
@@ -322,6 +323,7 @@ describe('run', () => {
     await command.run()
 
     expect(stderr.output).toMatch('Piped stdin is not supported')
+    expect(stderr.output).toMatch('aio runtime sandbox exec')
     expect(stderr.output).not.toMatch('CLIError')
     expect(process.exitCode).toBe(2)
     expect(handleError).not.toHaveBeenCalled()
@@ -338,6 +340,7 @@ describe('run', () => {
     await command.run()
 
     expect(stderr.output).toMatch('Piped stdin is not supported')
+    expect(stderr.output).toMatch('aio runtime sandbox exec')
     expect(stderr.output).not.toMatch('CLIError')
     expect(process.exitCode).toBe(2)
     expect(handleError).not.toHaveBeenCalled()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a new aio runtime sandbox exec command. it is an non-interactive counterpart to aio runtime sandbox run. It creates a sandbox, runs one or more commands, then tears the sandbox down.

Commands can be provided as:

a one-shot quoted argument: aio runtime sandbox exec "node --version"
a newline-separated list via --file: aio runtime sandbox exec --file commands.txt (-f)
both the one-shot command runs first, then the file's commands in order
It supports the same sandbox flags as run (--name, --port, --egress, --max-lifetime) plus two exec-specific flags: --command-timeout (per-command, default 30s) and --fail-fast (stop on the first non-zero exit; otherwise all commands run and the process exits with the last non-zero code). run now emits a soft hint pointing users to exec when they pass a command or piped input.

## Related Issue

https://jira.corp.adobe.com/browse/ACNA-4665

## Motivation and Context

`run` is only for interactive use. It does not support `"command"` or commands from stdin. We also found that using file redirection could cause issues.

`exec` solves this problem. It reads all commands from stdin before running them, so `exec -f commands.txt` works reliably. This gives us a simple way to run one-time commands or a list of commands in scripts, CI pipelines, or automation tools, while keeping `run` for interactive use.


## How Has This Been Tested?

1. npm lint 
2. npm test
3. manually tried different exec commands by linking the local version to the `aio cli`
e.g
```
aio runtime sandbox exec "echo hello world"                    
 ›   Warning: @adobe/aio-cli update available from 11.0.2 to 11.1.2.
 ›   Run npm install -g @adobe/aio-cli to update.
 ›   Warning: @adobe/aio-cli-plugin-api-mesh update available from 5.6.1 to 5.7.0
 ›   Warning: Run aio plugins:install @adobe/aio-cli-plugin-api-mesh to update to 
 ›   the latest

Creating sandbox...
[aio-lib-sandbox] alpha — APIs may change without notice
Created: sb-c8453286e1c54a57
Network policy: default-deny (DNS + NATS only)

$ echo hello world
hello world
[exit: 0]
Sandbox destroyed.
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
